### PR TITLE
Persistence integration

### DIFF
--- a/TheAlienThatEatsTheCarrot/Base.lproj/Main.storyboard
+++ b/TheAlienThatEatsTheCarrot/Base.lproj/Main.storyboard
@@ -1368,7 +1368,7 @@
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oPP-Hr-O1e">
-                                <rect key="frame" x="661" y="457.5" width="97" height="42"/>
+                                <rect key="frame" x="661" y="459.5" width="97" height="42"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="CANCEL"/>
@@ -1377,13 +1377,16 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qGF-uX-5mW">
-                                <rect key="frame" x="415" y="461" width="60" height="35"/>
+                                <rect key="frame" x="415" y="463" width="60" height="35"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="EYr-Xf-Vrn"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="SAVE"/>
+                                <connections>
+                                    <action selector="saveButtonPressed:" destination="TPg-5N-R8u" eventType="touchUpInside" id="CMP-ys-WGf"/>
+                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ENTER A LEVEL NAME: " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E3h-30-cNg">
                                 <rect key="frame" x="408.5" y="304" width="363" height="42"/>
@@ -1404,8 +1407,8 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LEVEL WITH SAME NAME CANNOT BE OVERWRITTEN" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g9N-nW-j7y">
-                                <rect key="frame" x="425" y="397" width="330" height="16"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <rect key="frame" x="403" y="397" width="374.5" height="18"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -1428,6 +1431,10 @@
                             <constraint firstItem="g9N-nW-j7y" firstAttribute="top" secondItem="vBx-IX-Pih" secondAttribute="bottom" constant="6" id="oiZ-Ue-HHX"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="informationLabel" destination="g9N-nW-j7y" id="nPx-gQ-DQ9"/>
+                        <outlet property="levelNameField" destination="vBx-IX-Pih" id="x56-BZ-AR9"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zdM-Tb-QpC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/TheAlienThatEatsTheCarrot/Base.lproj/Main.storyboard
+++ b/TheAlienThatEatsTheCarrot/Base.lproj/Main.storyboard
@@ -1319,6 +1319,9 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="LOAD"/>
+                                <connections>
+                                    <action selector="loadButtonTapped:" destination="cKT-R1-bh7" eventType="touchUpInside" id="dht-5A-jmC"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qtC-7g-YYY">
                                 <rect key="frame" x="661" y="509" width="97" height="42"/>
@@ -1326,7 +1329,7 @@
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="CANCEL"/>
                                 <connections>
-                                    <action selector="cancelButtonPressed:" destination="cKT-R1-bh7" eventType="touchUpInside" id="dGu-Jh-BDr"/>
+                                    <action selector="cancelButtonTapped:" destination="cKT-R1-bh7" eventType="touchUpInside" id="fbX-E5-rpd"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -1347,6 +1350,9 @@
                             <constraint firstItem="S0Z-r8-HIS" firstAttribute="leading" secondItem="194-Iu-5dK" secondAttribute="leading" constant="405" id="bcy-Ok-xQH"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="tableView" destination="x27-OW-L5m" id="br0-OQ-08e"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TgY-ME-sbS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/TheAlienThatEatsTheCarrot/Base.lproj/Main.storyboard
+++ b/TheAlienThatEatsTheCarrot/Base.lproj/Main.storyboard
@@ -1412,8 +1412,8 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LEVEL WITH SAME NAME CANNOT BE OVERWRITTEN" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g9N-nW-j7y">
-                                <rect key="frame" x="403" y="397" width="374.5" height="18"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g9N-nW-j7y">
+                                <rect key="frame" x="588" y="397" width="4" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>

--- a/TheAlienThatEatsTheCarrot/LevelDesigner/LevelDesigner.swift
+++ b/TheAlienThatEatsTheCarrot/LevelDesigner/LevelDesigner.swift
@@ -35,7 +35,6 @@ class LevelDesigner {
         guard let boardObject = level.findBoardObject(at: location) else {
             return
         }
-        print("handle pan start - object found")
         panObject = boardObject
     }
 
@@ -43,12 +42,10 @@ class LevelDesigner {
         guard let boardObject = panObject else {
             return
         }
-        print("handle pan change - object found")
         move(boardObject: boardObject, to: location)
     }
 
     func handlePanEnd() {
-        print("handle pan end")
         panObject = nil
     }
 
@@ -97,18 +94,16 @@ class LevelDesigner {
     }
 
     func move(boardObject: BoardObject, to location: CGPoint) {
-        print("object moving")
         remove(boardObject: boardObject)
 
         var newBoardObject = ObjectType.createObject(from: boardObject.type, position: location)
-        print("new object created")
         if !level.canAdd(boardObject: newBoardObject) {
             newBoardObject = boardObject
         }
         add(boardObject: newBoardObject)
         panObject = newBoardObject
     }
-    
+
     private func loadView(with boardObjects: BoardObjectSet) {
         for boardObject in boardObjects.allObjects {
             let id = ObjectIdentifier(boardObject)

--- a/TheAlienThatEatsTheCarrot/LevelDesigner/LevelDesigner.swift
+++ b/TheAlienThatEatsTheCarrot/LevelDesigner/LevelDesigner.swift
@@ -76,6 +76,10 @@ class LevelDesigner {
         loadView(with: level.boardObjects)
     }
 
+    func fetchLevelNames() -> [String] {
+        storageManager.fetchLevelNames()
+    }
+
     // MARK: - Delegating to view and model
     func add(boardObject: BoardObject, addToView: Bool = true) {
         if !level.canAdd(boardObject: boardObject) {

--- a/TheAlienThatEatsTheCarrot/LevelDesigner/LevelDesigner.swift
+++ b/TheAlienThatEatsTheCarrot/LevelDesigner/LevelDesigner.swift
@@ -10,19 +10,13 @@ import Foundation
 class LevelDesigner {
     var level: Level
     var view: LevelDesignerViewController
-//    private lazy var selectedTool: Tool = NormalPegTool(toolDelegate: self)
-//    var storageManager = StorageManager.sharedManager // for persistent storage
-//
+    var storageManager = LevelDataManager()
 
     init(area: CGRect, view: LevelDesignerViewController) {
         self.level = Level(area: area)
         self.view = view
     }
 
-//    func changeTool(to selectedTool: ToolType) {
-//        self.selectedTool = DefaultTool.factory(typeToCreate: selectedTool, delegate: self)
-//    }
-//
     func handleTap(at location: CGPoint, objectType: ObjectType) {
         let boardObject = ObjectType.createObject(from: objectType, position: location)
         add(boardObject: boardObject)
@@ -35,25 +29,6 @@ class LevelDesigner {
         remove(boardObject: boardObject)
     }
 
-//    func handlePinchStart(at location: CGPoint) {
-//        guard let boardObject = level.findBoardObject(at: location) else {
-//            return
-//        }
-//        panObject = boardObject
-//    }
-//
-//    func handlePinchChange(scale: CGFloat) {
-//        // if can scale, display new object
-//        guard let newGameObject = selectedTool.handlePinchChange(scale: scale) else {
-//            return
-//        }
-//        view.resizePinchImage(newGameObject: newGameObject)
-//    }
-//
-//    func handlePinchEnd() {
-//        selectedTool.handlePinchEnd()
-//    }
-//
     private var panObject: (any BoardObject)?
 
     func handlePanStart(at location: CGPoint) {
@@ -76,63 +51,41 @@ class LevelDesigner {
         print("handle pan end")
         panObject = nil
     }
-//
-//    func handleSwipeLeft(at touchPoint: CGPoint) {
-//        guard let peg = findGameObject(at: touchPoint) as? Peg else {
-//            // no peg obj found
-//            return
-//        }
-//        selectedTool.handleSwipeLeft(peg: peg)
-//    }
-//
-//    func handleSwipeRight(at touchPoint: CGPoint) {
-//        guard let peg = findGameObject(at: touchPoint) as? Peg else {
-//            // no peg obj found
-//            return
-//        }
-//        selectedTool.handleSwipeRight(peg: peg)
-//    }
-//
-//    func reset() {
-//        level.reset()
-//        view.reset()
-//    }
-//
-//    func save(levelName: String) throws {
-//        level.name = levelName
-//        try storageManager.saveLevel(level: level)
-//    }
-//
-//    func loadLevel(levelName: String) throws {
-//        reset()
-//        guard let levelData = try storageManager.fetchLevel(levelName: levelName) else {
-//            return
-//        }
-//        // level fetched successfully
-//        // set up Model and View
-//        self.level = try Level(data: levelData)
-//        view.loadLevel(with: level.gameObjects)
-//    }
-//
-//    func loadLevel(level: Level) {
-//        reset()
-//        // set up Model and View
-//        self.level = level
-//        view.loadLevel(with: level.gameObjects)
-//    }
-//
 
-//
+    func reset() {
+        level.reset()
+        view.reset()
+    }
+
+    func saveLevel(levelName: String, overwrite: Bool) throws {
+        level.name = levelName
+        try storageManager.saveLevelData(level: level, overwrite: overwrite)
+    }
+
+    func loadLevel(levelName: String) throws {
+        reset()
+        do {
+            let levelData = try storageManager.fetchLevelData(levelName: levelName)
+            self.level = try Level(data: levelData)
+            loadView(with: level.boardObjects)
+        } catch {
+            throw error
+        }
+    }
+
+    func loadLevel(level: Level) {
+        reset()
+        self.level = level
+        loadView(with: level.boardObjects)
+    }
+
     // MARK: - Delegating to view and model
     func add(boardObject: BoardObject, addToView: Bool = true) {
-        print("adding object - check canAdd()")
         if !level.canAdd(boardObject: boardObject) {
             return
         }
-        print("adding object to level")
         level.add(boardObject: boardObject)
         if addToView {
-            print("adding object to view")
             let id = ObjectIdentifier(boardObject)
             view.addImage(id: id, objectType: boardObject.type, center: boardObject.position, width: boardObject.width, height: boardObject.height)
         }
@@ -155,36 +108,11 @@ class LevelDesigner {
         add(boardObject: newBoardObject)
         panObject = newBoardObject
     }
-//
-//    func add(block: Block, addToView: Bool = true) {
-//        if !level.canAdd(gameObject: block) {
-//            return
-//        }
-//        level.add(gameObject: block)
-//        if addToView {
-//            view.addBlockImage(at: block.center, width: block.width, height: block.height, angle: block.angle)
-//        }
-//    }
-//
-//    func remove(block: Block) {
-//        level.remove(gameObject: block)
-//        view.removeBlockImage(at: block.center)
-//    }
-//
-//    func move(originalObject: any GameObject, newObject: any GameObject) {
-//        level.remove(gameObject: originalObject)
-//        level.add(gameObject: newObject)
-//    }
-//
-//    func findGameObject(at point: CGPoint) -> (any GameObject)? {
-//        level.findGameObject(at: point)
-//    }
-//
-//    func canAdd(gameObject: any GameObject) -> Bool {
-//        level.canAdd(gameObject: gameObject)
-//    }
-//
-//    func returnPanImage(center: CGPoint) {
-//        view.returnPanImage(center: center)
-//    }
+    
+    private func loadView(with boardObjects: BoardObjectSet) {
+        for boardObject in boardObjects.allObjects {
+            let id = ObjectIdentifier(boardObject)
+            view.addImage(id: id, objectType: boardObject.type, center: boardObject.position, width: boardObject.width, height: boardObject.height)
+        }
+    }
 }

--- a/TheAlienThatEatsTheCarrot/LevelView.xib
+++ b/TheAlienThatEatsTheCarrot/LevelView.xib
@@ -32,7 +32,7 @@
                     <color key="textColor" red="0.25882352941176467" green="0.090196078431372548" blue="0.039215686274509803" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LevelName" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uNr-1x-fVO">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LevelName" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uNr-1x-fVO">
                     <rect key="frame" x="114.5" y="74" width="149" height="37"/>
                     <fontDescription key="fontDescription" type="system" pointSize="31"/>
                     <color key="textColor" red="1" green="0.38823529411764707" blue="0.19607843137254902" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/TheAlienThatEatsTheCarrot/Model/BoardObject/BoardObjectSet.swift
+++ b/TheAlienThatEatsTheCarrot/Model/BoardObject/BoardObjectSet.swift
@@ -112,7 +112,7 @@ struct BoardObjectSet {
             return object.position
         }
     }
-    
+
     mutating func removeAll() {
         blocks.removeAll()
         collectables.removeAll()

--- a/TheAlienThatEatsTheCarrot/Model/BoardObject/BoardObjectSet.swift
+++ b/TheAlienThatEatsTheCarrot/Model/BoardObject/BoardObjectSet.swift
@@ -112,4 +112,11 @@ struct BoardObjectSet {
             return object.position
         }
     }
+    
+    mutating func removeAll() {
+        blocks.removeAll()
+        collectables.removeAll()
+        enemies.removeAll()
+        powerups.removeAll()
+    }
 }

--- a/TheAlienThatEatsTheCarrot/Model/Level.swift
+++ b/TheAlienThatEatsTheCarrot/Model/Level.swift
@@ -42,4 +42,8 @@ struct Level {
     func nearestNonOverlappingPosition(for object: BoardObject) -> CGPoint {
         boardObjects.nearestNonOverlappingPosition(for: object)
     }
+    
+    mutating func reset() {
+        boardObjects.removeAll()
+    }
 }

--- a/TheAlienThatEatsTheCarrot/Model/Level.swift
+++ b/TheAlienThatEatsTheCarrot/Model/Level.swift
@@ -42,7 +42,7 @@ struct Level {
     func nearestNonOverlappingPosition(for object: BoardObject) -> CGPoint {
         boardObjects.nearestNonOverlappingPosition(for: object)
     }
-    
+
     mutating func reset() {
         boardObjects.removeAll()
     }

--- a/TheAlienThatEatsTheCarrot/Persistence/CoreDataManager.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/CoreDataManager.swift
@@ -25,7 +25,7 @@ class CoreDataManager {
          application to it. This property is optional since there are legitimate
          error conditions that could cause the creation of the store to fail.
          */
-        let container = NSPersistentContainer(name: "PeggleData")
+        let container = NSPersistentContainer(name: "TheAlienThatEastsTheCarrot")
         container.loadPersistentStores(completionHandler: { _, error in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.

--- a/TheAlienThatEatsTheCarrot/Persistence/LevelDataManager.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/LevelDataManager.swift
@@ -21,10 +21,9 @@ struct LevelDataManager {
     ///   - Returns : the fetched `LevelData`.
     func fetchLevelData(levelName: String) throws -> LevelData {
         let levelDatas = try fetchAllLevelDataMatching(levelName: levelName)
-        guard !levelDatas.isEmpty else {
+        if levelDatas.isEmpty {
             throw TheAlienThatEatsTheCarrotError.invalidPersistenceDataError
-        }
-        guard levelDatas.count == 1 else {
+        } else if levelDatas.count > 1 {
             throw TheAlienThatEatsTheCarrotError.duplicateLevelNameError(levelName: levelName)
         }
         return levelDatas[0]
@@ -37,19 +36,15 @@ struct LevelDataManager {
     ///     - level: the `Level` to be saved.
     ///     - overwrite: whether or not to overwrite any existing `LevelData` with the same name.
     func saveLevelData(level: Level, overwrite: Bool = false) throws {
-        print("saving level \(level.name) \(overwrite)")
         if let matchingLevelData = try? fetchAllLevelDataMatching(levelName: level.name) {
             if !overwrite {
-                print("path1")
                 throw TheAlienThatEatsTheCarrotError.duplicateLevelNameError(levelName: level.name)
             } else {
-                print("path2")
                 for duplicate in matchingLevelData {
                     context.delete(duplicate)
                 }
             }
         }
-        print("saving")
         _ = level.toData(context: context)
         try context.save()
     }

--- a/TheAlienThatEatsTheCarrot/Persistence/LevelDataManager.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/LevelDataManager.swift
@@ -37,17 +37,19 @@ struct LevelDataManager {
     ///     - level: the `Level` to be saved.
     ///     - overwrite: whether or not to overwrite any existing `LevelData` with the same name.
     func saveLevelData(level: Level, overwrite: Bool = false) throws {
-        guard let matchingLevelData = try? fetchAllLevelDataMatching(levelName: level.name) else {
-            return
-        }
-        let containsDuplicate = !matchingLevelData.isEmpty
-        if containsDuplicate && !overwrite {
-            throw TheAlienThatEatsTheCarrotError.duplicateLevelNameError(levelName: level.name)
-        } else if containsDuplicate {
-            for duplicate in matchingLevelData {
-                context.delete(duplicate)
+        print("saving level \(level.name) \(overwrite)")
+        if let matchingLevelData = try? fetchAllLevelDataMatching(levelName: level.name) {
+            if !overwrite {
+                print("path1")
+                throw TheAlienThatEatsTheCarrotError.duplicateLevelNameError(levelName: level.name)
+            } else {
+                print("path2")
+                for duplicate in matchingLevelData {
+                    context.delete(duplicate)
+                }
             }
         }
+        print("saving")
         _ = level.toData(context: context)
         try context.save()
     }

--- a/TheAlienThatEatsTheCarrot/Persistence/LevelDataManager.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/LevelDataManager.swift
@@ -36,7 +36,8 @@ struct LevelDataManager {
     ///     - level: the `Level` to be saved.
     ///     - overwrite: whether or not to overwrite any existing `LevelData` with the same name.
     func saveLevelData(level: Level, overwrite: Bool = false) throws {
-        if let matchingLevelData = try? fetchAllLevelDataMatching(levelName: level.name) {
+        let matchingLevelData = try fetchAllLevelDataMatching(levelName: level.name)
+        if !matchingLevelData.isEmpty {
             if !overwrite {
                 throw TheAlienThatEatsTheCarrotError.duplicateLevelNameError(levelName: level.name)
             } else {
@@ -64,5 +65,19 @@ struct LevelDataManager {
         let pred = NSPredicate(format: filter)
         request.predicate = pred
         return request
+    }
+
+    func fetchLevelNames() -> [String] {
+        do {
+            let levelDatas = try fetchAllLevelData()
+            if levelDatas.isEmpty {
+                return []
+            }
+            let levelNames = levelDatas.compactMap({ $0.name })
+            return levelNames
+        } catch {
+            print("Error fetching level data: \(error)")
+            return []
+        }
     }
 }

--- a/TheAlienThatEatsTheCarrot/Persistence/extensions/Block+extensions.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/extensions/Block+extensions.swift
@@ -10,7 +10,7 @@ import CoreData
 extension Block: FromDataAble {
     convenience init(data: BlockData) throws {
         guard let positionData = data.position, let blockTypeData = data.type else {
-            
+
             throw TheAlienThatEatsTheCarrotError.invalidObjectTypeDataError(typeName: "block")
         }
         let position = try CGPoint(data: positionData)

--- a/TheAlienThatEatsTheCarrot/Persistence/extensions/Block+extensions.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/extensions/Block+extensions.swift
@@ -9,12 +9,16 @@ import CoreData
 
 extension Block: FromDataAble {
     convenience init(data: BlockData) throws {
-        guard let positionData = data.position, let blockTypeData = data.type, let containedPowerupData = data.contains else {
+        guard let positionData = data.position, let blockTypeData = data.type else {
+            
             throw TheAlienThatEatsTheCarrotError.invalidObjectTypeDataError(typeName: "block")
         }
         let position = try CGPoint(data: positionData)
         let blockType = try BlockType(data: blockTypeData)
-        let containedPowerupType = try PowerupType(data: containedPowerupData)
+        var containedPowerupType: PowerupType?
+        if let containedPowerupData = data.contains {
+            containedPowerupType = try PowerupType(data: containedPowerupData)
+        }
         self.init(blockType: blockType, containedPowerupType: containedPowerupType, position: position)
     }
 }

--- a/TheAlienThatEatsTheCarrot/Persistence/extensions/CollectableType+extensions.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/extensions/CollectableType+extensions.swift
@@ -19,7 +19,7 @@ extension CollectableType: FromDataAble {
 
 extension CollectableType: ToDataAble {
     func toData(context: NSManagedObjectContext) -> NSManagedObject {
-        let collectableTypeData = BlockTypeData(context: context)
+        let collectableTypeData = CollectableTypeData(context: context)
         collectableTypeData.typeName = self.rawValue
         return collectableTypeData as NSManagedObject
     }

--- a/TheAlienThatEatsTheCarrot/Persistence/extensions/Enemy+extensions.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/extensions/Enemy+extensions.swift
@@ -20,9 +20,9 @@ extension Enemy: FromDataAble {
 
 extension Enemy: ToDataAble {
     func toData(context: NSManagedObjectContext) -> NSManagedObject {
-        let enemyData = CollectableData(context: context)
+        let enemyData = EnemyData(context: context)
         enemyData.position = self.position.toData(context: context) as? CGPointData
-        enemyData.type = self.enemyType.toData(context: context) as? CollectableTypeData
+        enemyData.type = self.enemyType.toData(context: context) as? EnemyTypeData
         return enemyData as NSManagedObject
     }
 }

--- a/TheAlienThatEatsTheCarrot/Persistence/extensions/Level+extensions.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/extensions/Level+extensions.swift
@@ -90,12 +90,12 @@ extension Level: ToDataAble {
         let levelData = LevelData(context: context)
         levelData.name = name
         levelData.areaData = area.toData(context: context) as? CGRectData
-        
+
         var blockDatas = Set<BlockData>()
         var collectableDatas = Set<CollectableData>()
         var enemyDatas = Set<EnemyData>()
         var powerupDatas = Set<PowerupData>()
-        
+
         for block in self.boardObjects.blocks {
             if let blockData = block.toData(context: context) as? BlockData {
                 blockDatas.insert(blockData)
@@ -116,12 +116,12 @@ extension Level: ToDataAble {
                 powerupDatas.insert(powerupData)
             }
         }
-        
+
         levelData.addToBlockDatas(NSSet(set: blockDatas))
         levelData.addToCollectableDatas(NSSet(set: collectableDatas))
         levelData.addToEnemyDatas(NSSet(set: enemyDatas))
         levelData.addToPowerupDatas(NSSet(set: powerupDatas))
-        
+
         return levelData as NSManagedObject
     }
 }

--- a/TheAlienThatEatsTheCarrot/Persistence/extensions/Level+extensions.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/extensions/Level+extensions.swift
@@ -90,26 +90,38 @@ extension Level: ToDataAble {
         let levelData = LevelData(context: context)
         levelData.name = name
         levelData.areaData = area.toData(context: context) as? CGRectData
+        
+        var blockDatas = Set<BlockData>()
+        var collectableDatas = Set<CollectableData>()
+        var enemyDatas = Set<EnemyData>()
+        var powerupDatas = Set<PowerupData>()
+        
         for block in self.boardObjects.blocks {
             if let blockData = block.toData(context: context) as? BlockData {
-                levelData.addToBlockDatas(blockData)
+                blockDatas.insert(blockData)
             }
         }
         for collectable in self.boardObjects.collectables {
             if let collectableData = collectable.toData(context: context) as? CollectableData {
-                levelData.addToCollectableDatas(collectableData)
+                collectableDatas.insert(collectableData)
             }
         }
         for enemy in self.boardObjects.enemies {
             if let enemyData = enemy.toData(context: context) as? EnemyData {
-                levelData.addToEnemyDatas(enemyData)
+                enemyDatas.insert(enemyData)
             }
         }
         for powerup in self.boardObjects.powerups {
             if let powerupData = powerup.toData(context: context) as? PowerupData {
-                levelData.addToPowerupDatas(powerupData)
+                powerupDatas.insert(powerupData)
             }
         }
+        
+        levelData.addToBlockDatas(NSSet(set: blockDatas))
+        levelData.addToCollectableDatas(NSSet(set: collectableDatas))
+        levelData.addToEnemyDatas(NSSet(set: enemyDatas))
+        levelData.addToPowerupDatas(NSSet(set: powerupDatas))
+        
         return levelData as NSManagedObject
     }
 }

--- a/TheAlienThatEatsTheCarrot/Persistence/extensions/Powerup+extensions.swift
+++ b/TheAlienThatEatsTheCarrot/Persistence/extensions/Powerup+extensions.swift
@@ -20,9 +20,9 @@ extension Powerup: FromDataAble {
 
 extension Powerup: ToDataAble {
     func toData(context: NSManagedObjectContext) -> NSManagedObject {
-        let powerupData = CollectableData(context: context)
+        let powerupData = PowerupData(context: context)
         powerupData.position = self.position.toData(context: context) as? CGPointData
-        powerupData.type = self.powerupType.toData(context: context) as? CollectableTypeData
+        powerupData.type = self.powerupType.toData(context: context) as? PowerupTypeData
         return powerupData as NSManagedObject
     }
 }

--- a/TheAlienThatEatsTheCarrot/TheAlienThatEastsTheCarrot.xcdatamodeld/TheAlienThatEastsTheCarrot.xcdatamodel/contents
+++ b/TheAlienThatEatsTheCarrot/TheAlienThatEastsTheCarrot.xcdatamodeld/TheAlienThatEastsTheCarrot.xcdatamodel/contents
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23C71" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
-    <entity name="BlockData" representedClassName="BlockData" syncable="YES" codeGenerationType="class">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="21G72" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="BlockData" representedClassName=".BlockData" syncable="YES" codeGenerationType="class">
         <relationship name="contains" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PowerupTypeData" inverseName="containedBy" inverseEntity="PowerupTypeData"/>
         <relationship name="levelData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LevelData" inverseName="blockDatas" inverseEntity="LevelData"/>
         <relationship name="position" maxCount="1" deletionRule="Nullify" destinationEntity="CGPointData" inverseName="blockData" inverseEntity="CGPointData"/>
-        <relationship name="type" maxCount="1" deletionRule="Nullify" destinationEntity="BlockTypeData" inverseName="blockData" inverseEntity="BlockTypeData"/>
+        <relationship name="type" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BlockTypeData" inverseName="blockData" inverseEntity="BlockTypeData"/>
     </entity>
-    <entity name="BlockTypeData" representedClassName="BlockTypeData" syncable="YES" codeGenerationType="class">
+    <entity name="BlockTypeData" representedClassName=".BlockTypeData" syncable="YES" codeGenerationType="class">
         <attribute name="typeName" optional="YES" attributeType="String"/>
         <relationship name="blockData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BlockData" inverseName="type" inverseEntity="BlockData"/>
     </entity>
-    <entity name="CGPointData" representedClassName="CGPointData" syncable="YES" codeGenerationType="class">
+    <entity name="CGPointData" representedClassName=".CGPointData" syncable="YES" codeGenerationType="class">
         <attribute name="x" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="y" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <relationship name="blockData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BlockData" inverseName="position" inverseEntity="BlockData"/>
@@ -19,44 +19,44 @@
         <relationship name="enemyData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="EnemyData" inverseName="position" inverseEntity="EnemyData"/>
         <relationship name="powerupData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PowerupData" inverseName="position" inverseEntity="PowerupData"/>
     </entity>
-    <entity name="CGRectData" representedClassName="CGRectData" syncable="YES" codeGenerationType="class">
+    <entity name="CGRectData" representedClassName=".CGRectData" syncable="YES" codeGenerationType="class">
         <attribute name="height" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="width" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <relationship name="levelData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LevelData" inverseName="areaData" inverseEntity="LevelData"/>
-        <relationship name="position" maxCount="1" deletionRule="Nullify" destinationEntity="CGPointData" inverseName="cGRectData" inverseEntity="CGPointData"/>
+        <relationship name="position" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CGPointData" inverseName="cGRectData" inverseEntity="CGPointData"/>
     </entity>
-    <entity name="CollectableData" representedClassName="CollectableData" syncable="YES" codeGenerationType="class">
+    <entity name="CollectableData" representedClassName=".CollectableData" syncable="YES" codeGenerationType="class">
         <relationship name="levelData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LevelData" inverseName="collectableDatas" inverseEntity="LevelData"/>
-        <relationship name="position" maxCount="1" deletionRule="Nullify" destinationEntity="CGPointData" inverseName="collectableData" inverseEntity="CGPointData"/>
-        <relationship name="type" maxCount="1" deletionRule="Nullify" destinationEntity="CollectableTypeData" inverseName="collectableData" inverseEntity="CollectableTypeData"/>
+        <relationship name="position" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CGPointData" inverseName="collectableData" inverseEntity="CGPointData"/>
+        <relationship name="type" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CollectableTypeData" inverseName="collectableData" inverseEntity="CollectableTypeData"/>
     </entity>
-    <entity name="CollectableTypeData" representedClassName="CollectableTypeData" syncable="YES" codeGenerationType="class">
+    <entity name="CollectableTypeData" representedClassName=".CollectableTypeData" syncable="YES" codeGenerationType="class">
         <attribute name="typeName" optional="YES" attributeType="String"/>
         <relationship name="collectableData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CollectableData" inverseName="type" inverseEntity="CollectableData"/>
     </entity>
-    <entity name="EnemyData" representedClassName="EnemyData" syncable="YES" codeGenerationType="class">
+    <entity name="EnemyData" representedClassName=".EnemyData" syncable="YES" codeGenerationType="class">
         <relationship name="levelData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LevelData" inverseName="enemyDatas" inverseEntity="LevelData"/>
-        <relationship name="position" maxCount="1" deletionRule="Nullify" destinationEntity="CGPointData" inverseName="enemyData" inverseEntity="CGPointData"/>
-        <relationship name="type" maxCount="1" deletionRule="Nullify" destinationEntity="EnemyTypeData" inverseName="enemyData" inverseEntity="EnemyTypeData"/>
+        <relationship name="position" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CGPointData" inverseName="enemyData" inverseEntity="CGPointData"/>
+        <relationship name="type" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="EnemyTypeData" inverseName="enemyData" inverseEntity="EnemyTypeData"/>
     </entity>
-    <entity name="EnemyTypeData" representedClassName="EnemyTypeData" syncable="YES" codeGenerationType="class">
+    <entity name="EnemyTypeData" representedClassName=".EnemyTypeData" syncable="YES" codeGenerationType="class">
         <attribute name="typeName" optional="YES" attributeType="String"/>
         <relationship name="enemyData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="EnemyData" inverseName="type" inverseEntity="EnemyData"/>
     </entity>
-    <entity name="LevelData" representedClassName="LevelData" syncable="YES" codeGenerationType="class">
+    <entity name="LevelData" representedClassName=".LevelData" syncable="YES" codeGenerationType="class">
         <attribute name="name" optional="YES" attributeType="String"/>
-        <relationship name="areaData" maxCount="1" deletionRule="Nullify" destinationEntity="CGRectData" inverseName="levelData" inverseEntity="CGRectData"/>
-        <relationship name="blockDatas" toMany="YES" deletionRule="Nullify" destinationEntity="BlockData" inverseName="levelData" inverseEntity="BlockData"/>
-        <relationship name="collectableDatas" toMany="YES" deletionRule="Nullify" destinationEntity="CollectableData" inverseName="levelData" inverseEntity="CollectableData"/>
-        <relationship name="enemyDatas" toMany="YES" deletionRule="Nullify" destinationEntity="EnemyData" inverseName="levelData" inverseEntity="EnemyData"/>
-        <relationship name="powerupDatas" toMany="YES" deletionRule="Nullify" destinationEntity="PowerupData" inverseName="levelData" inverseEntity="PowerupData"/>
+        <relationship name="areaData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CGRectData" inverseName="levelData" inverseEntity="CGRectData"/>
+        <relationship name="blockDatas" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="BlockData" inverseName="levelData" inverseEntity="BlockData"/>
+        <relationship name="collectableDatas" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CollectableData" inverseName="levelData" inverseEntity="CollectableData"/>
+        <relationship name="enemyDatas" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EnemyData" inverseName="levelData" inverseEntity="EnemyData"/>
+        <relationship name="powerupDatas" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PowerupData" inverseName="levelData" inverseEntity="PowerupData"/>
     </entity>
-    <entity name="PowerupData" representedClassName="PowerupData" syncable="YES" codeGenerationType="class">
+    <entity name="PowerupData" representedClassName=".PowerupData" syncable="YES" codeGenerationType="class">
         <relationship name="levelData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LevelData" inverseName="powerupDatas" inverseEntity="LevelData"/>
-        <relationship name="position" maxCount="1" deletionRule="Nullify" destinationEntity="CGPointData" inverseName="powerupData" inverseEntity="CGPointData"/>
-        <relationship name="type" maxCount="1" deletionRule="Nullify" destinationEntity="PowerupTypeData" inverseName="powerupData" inverseEntity="PowerupTypeData"/>
+        <relationship name="position" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CGPointData" inverseName="powerupData" inverseEntity="CGPointData"/>
+        <relationship name="type" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PowerupTypeData" inverseName="powerupData" inverseEntity="PowerupTypeData"/>
     </entity>
-    <entity name="PowerupTypeData" representedClassName="PowerupTypeData" syncable="YES" codeGenerationType="class">
+    <entity name="PowerupTypeData" representedClassName=".PowerupTypeData" syncable="YES" codeGenerationType="class">
         <attribute name="typeName" optional="YES" attributeType="String"/>
         <relationship name="containedBy" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BlockData" inverseName="contains" inverseEntity="BlockData"/>
         <relationship name="powerupData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PowerupData" inverseName="type" inverseEntity="PowerupData"/>

--- a/TheAlienThatEatsTheCarrot/View/GamePlay/GamePlayViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/GamePlay/GamePlayViewController.swift
@@ -75,33 +75,28 @@ class GamePlayViewController: UIViewController {
     @IBAction private func moveLeftButtonTouchDown(_ sender: UIButton) {
         sender.backgroundColor = sender.backgroundColor?.withAlphaComponent(0.5)
         isLeftButtonPressed = true
-        print("left true")
         EventManager.shared.postEvent(PlayerControlActionEvent(action: .left))
     }
 
     @IBAction private func moveLeftButtonTouchUp(_ sender: UIButton) {
         sender.backgroundColor = sender.backgroundColor?.withAlphaComponent(0.3)
         isLeftButtonPressed = false
-        print("left false")
         EventManager.shared.postEvent(PlayerControlActionEvent(action: .idle))
     }
 
     @IBAction private func moveRightButtonTouchDown(_ sender: UIButton) {
         sender.backgroundColor = sender.backgroundColor?.withAlphaComponent(0.5)
         isLeftButtonPressed = true
-        print("right true")
         EventManager.shared.postEvent(PlayerControlActionEvent(action: .right))
     }
 
     @IBAction private func moveRightButtonTouchUp(_ sender: UIButton) {
         sender.backgroundColor = sender.backgroundColor?.withAlphaComponent(0.3)
         isLeftButtonPressed = false
-        print("right false")
         EventManager.shared.postEvent(PlayerControlActionEvent(action: .idle))
     }
 
     @IBAction private func jumpButtonTapped(_ sender: UIButton) {
-        print("jump")
         EventManager.shared.postEvent(PlayerControlActionEvent(action: .jump))
     }
 
@@ -113,7 +108,6 @@ class GamePlayViewController: UIViewController {
 
     @IBAction private func unwindFromPauseScreen(segue: UIStoryboardSegue) {
         // This method will be called when the PauseScreenViewController is dismissed
-        print("start agains")
         startGameLoop()
     }
 

--- a/TheAlienThatEatsTheCarrot/View/LevelDesigner/LevelDesignerViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelDesigner/LevelDesignerViewController.swift
@@ -77,10 +77,11 @@ class LevelDesignerViewController: UIViewController {
            let destination = segue.destination as? SaveLevelViewController {
             destination.delegate = self
         }
-//        if segue.identifier == "LoadLevelSegue",
-//           let destination = segue.destination as? LoadLevelViewController {
-//            destination.delegate = self
-//        }
+        if segue.identifier == "LoadLevelSegue",
+           let destination = segue.destination as? LoadLevelViewController {
+            destination.delegate = self
+            destination.levelNames = ["a", "b", "c"]
+        }
 //        if segue.identifier == "TestGameSegue",
 //           let gameViewController = segue.destination as? GameViewController {
 //            gameViewController.level = levelDesigner.level
@@ -159,28 +160,26 @@ class LevelDesignerViewController: UIViewController {
 
     // MARK: - image handling
     func addImage(id: ObjectIdentifier, objectType: ObjectType, center: CGPoint, width: CGFloat, height: CGFloat) {
-        print("image added at \(center) for \(id)")
+//        print("image added at \(center) for \(id)")
         let imageView = RectangularImageView(objectType: objectType, center: center, width: width, height: height)
         imageViews[id] = imageView
         boardAreaView.addSubview(imageView.imageView)
     }
 
     func removeImage(id: ObjectIdentifier) {
-        print("image removed for \(id)")
+//        print("image removed for \(id)")
         guard let removedImageView = imageViews.removeValue(forKey: id) else {
             return
         }
         removedImageView.imageView.removeFromSuperview()
         removedImageView.imageView = nil
     }
-    
-    
 
     // MARK: - other feature buttons
     @IBAction private func backButtonPressed(_ sender: UIButton) {
         dismiss(animated: true)
     }
-    
+
     func reset() {
         for imageView in imageViews.values {
             imageView.imageView.removeFromSuperview()
@@ -188,18 +187,23 @@ class LevelDesignerViewController: UIViewController {
         }
         imageViews.removeAll()
     }
-    
+
 }
 
 extension LevelDesignerViewController: ComponentSelectDelegate {
     func buttonTapped(type: ObjectType) {
         componentSelected = type
-        print("Type selecteed: \(type)")
     }
 }
 
 extension LevelDesignerViewController: SaveLevelViewControllerDelegate {
     func saveLevel(levelName: String, overwrite: Bool) throws {
         try levelDesigner.saveLevel(levelName: levelName, overwrite: overwrite)
+    }
+}
+
+extension LevelDesignerViewController: LoadLevelViewControllerDelegate {
+    func loadLevel(levelName: String) throws {
+        try levelDesigner.loadLevel(levelName: levelName)
     }
 }

--- a/TheAlienThatEatsTheCarrot/View/LevelDesigner/LevelDesignerViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelDesigner/LevelDesignerViewController.swift
@@ -73,6 +73,18 @@ class LevelDesignerViewController: UIViewController {
                 collectivlesViewController.delegate = self
             }
         }
+        if segue.identifier == "SaveLevelSegue",
+           let destination = segue.destination as? SaveLevelViewController {
+            destination.delegate = self
+        }
+//        if segue.identifier == "LoadLevelSegue",
+//           let destination = segue.destination as? LoadLevelViewController {
+//            destination.delegate = self
+//        }
+//        if segue.identifier == "TestGameSegue",
+//           let gameViewController = segue.destination as? GameViewController {
+//            gameViewController.level = levelDesigner.level
+//        }
     }
 
     private func hideAllContainers() {
@@ -161,16 +173,33 @@ class LevelDesignerViewController: UIViewController {
         removedImageView.imageView.removeFromSuperview()
         removedImageView.imageView = nil
     }
+    
+    
 
     // MARK: - other feature buttons
     @IBAction private func backButtonPressed(_ sender: UIButton) {
         dismiss(animated: true)
     }
+    
+    func reset() {
+        for imageView in imageViews.values {
+            imageView.imageView.removeFromSuperview()
+            imageView.imageView = nil
+        }
+        imageViews.removeAll()
+    }
+    
 }
 
 extension LevelDesignerViewController: ComponentSelectDelegate {
     func buttonTapped(type: ObjectType) {
         componentSelected = type
         print("Type selecteed: \(type)")
+    }
+}
+
+extension LevelDesignerViewController: SaveLevelViewControllerDelegate {
+    func saveLevel(levelName: String, overwrite: Bool) throws {
+        try levelDesigner.saveLevel(levelName: levelName, overwrite: overwrite)
     }
 }

--- a/TheAlienThatEatsTheCarrot/View/LevelDesigner/LevelDesignerViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelDesigner/LevelDesignerViewController.swift
@@ -80,7 +80,7 @@ class LevelDesignerViewController: UIViewController {
         if segue.identifier == "LoadLevelSegue",
            let destination = segue.destination as? LoadLevelViewController {
             destination.delegate = self
-            destination.levelNames = ["a", "b", "c"]
+            destination.levelNames = levelDesigner.fetchLevelNames()
         }
 //        if segue.identifier == "TestGameSegue",
 //           let gameViewController = segue.destination as? GameViewController {

--- a/TheAlienThatEatsTheCarrot/View/LevelDesigner/LoadLevelViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelDesigner/LoadLevelViewController.swift
@@ -7,10 +7,56 @@
 
 import UIKit
 
-class LoadLevelViewController: UIViewController {
+class LoadLevelViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+    @IBOutlet var tableView: UITableView!
 
-    @IBAction private func cancelButtonPressed(_ sender: UIButton) {
-        dismiss(animated: true)
+    var levelNames: [String]!
+    weak var delegate: LoadLevelViewControllerDelegate?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.delegate = self
+        tableView.dataSource = self
+//        tableView.backgroundColor = .clear
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "LevelCell")
     }
 
+    // MARK: - UITableView DataSource
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        levelNames.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "LevelCell", for: indexPath)
+        cell.textLabel?.text = levelNames[indexPath.row]
+        cell.textLabel?.font = UIFont.systemFont(ofSize: 20)
+//        cell.backgroundColor = .clear
+        return cell
+    }
+
+    // MARK: - UITableView Delegate
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    }
+
+    @IBAction private func loadButtonTapped(_ sender: UIButton) {
+        guard let selectedRow = tableView.indexPathForSelectedRow else {
+            // No row is selected, return
+            return
+        }
+        do {
+            try delegate?.loadLevel(levelName: levelNames[selectedRow.row])
+        } catch {
+            return
+        }
+    }
+
+    @IBAction private func cancelButtonTapped(_ sender: UIButton) {
+        dismiss(animated: true)
+    }
+}
+
+protocol LoadLevelViewControllerDelegate: AnyObject {
+    func loadLevel(levelName: String) throws
 }

--- a/TheAlienThatEatsTheCarrot/View/LevelDesigner/LoadLevelViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelDesigner/LoadLevelViewController.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 class LoadLevelViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-    @IBOutlet var tableView: UITableView!
 
+    @IBOutlet private var tableView: UITableView!
     var levelNames: [String]!
     weak var delegate: LoadLevelViewControllerDelegate?
 

--- a/TheAlienThatEatsTheCarrot/View/LevelDesigner/SaveLevelViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelDesigner/SaveLevelViewController.swift
@@ -12,12 +12,12 @@ class SaveLevelViewController: UIViewController {
     @IBOutlet private var informationLabel: UILabel!
     @IBOutlet private var levelNameField: UITextField!
     weak var delegate: SaveLevelViewControllerDelegate?
-    private var overwrite: Bool = false
-    
+    private var overwrite = false
+
     @IBAction private func cancelButtonPressed(_ sender: UIButton) {
         dismiss(animated: true)
     }
-    
+
     @IBAction func saveButtonPressed(_ sender: UIButton) {
         guard let levelName = levelNameField.text, !levelName.isEmpty else {
             informationLabel.text = "PLEASE ENTER A LEVEL NAME"
@@ -36,7 +36,7 @@ class SaveLevelViewController: UIViewController {
             throwAlert(message: "Unexpected error: \(error)")
         }
     }
-    
+
     private func throwAlert(message: String) {
         let alertMessage = message
         let alert = UIAlertController(title: "Error", message: alertMessage, preferredStyle: .alert)
@@ -44,7 +44,7 @@ class SaveLevelViewController: UIViewController {
         alert.addAction(okAction)
         self.present(alert, animated: true, completion: nil)
     }
-    
+
 }
 
 protocol SaveLevelViewControllerDelegate: AnyObject {

--- a/TheAlienThatEatsTheCarrot/View/LevelDesigner/SaveLevelViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelDesigner/SaveLevelViewController.swift
@@ -9,8 +9,44 @@ import UIKit
 
 class SaveLevelViewController: UIViewController {
 
+    @IBOutlet private var informationLabel: UILabel!
+    @IBOutlet private var levelNameField: UITextField!
+    weak var delegate: SaveLevelViewControllerDelegate?
+    private var overwrite: Bool = false
+    
     @IBAction private func cancelButtonPressed(_ sender: UIButton) {
         dismiss(animated: true)
     }
+    
+    @IBAction func saveButtonPressed(_ sender: UIButton) {
+        guard let levelName = levelNameField.text, !levelName.isEmpty else {
+            informationLabel.text = "PLEASE ENTER A LEVEL NAME"
+            return
+        }
+        do {
+            try delegate?.saveLevel(levelName: levelName, overwrite: overwrite)
+            informationLabel.text = "LEVEL SAVED SUCCESSFULLY!"
+            overwrite = false
+        } catch TheAlienThatEatsTheCarrotError.duplicateLevelNameError {
+            informationLabel.text = "LEVEL EXISTS, SAVE AGAIN TO OVERWRITE"
+            self.overwrite = true
+//        } catch PeggleError.cannotOverrideDefaultLevelError {
+//            informationLabel.text = "Default levels cannot be overidden."
+        } catch {
+            throwAlert(message: "Unexpected error: \(error)")
+        }
+    }
+    
+    private func throwAlert(message: String) {
+        let alertMessage = message
+        let alert = UIAlertController(title: "Error", message: alertMessage, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "Okay", style: .default)
+        alert.addAction(okAction)
+        self.present(alert, animated: true, completion: nil)
+    }
+    
+}
 
+protocol SaveLevelViewControllerDelegate: AnyObject {
+    func saveLevel(levelName: String, overwrite: Bool) throws
 }

--- a/TheAlienThatEatsTheCarrot/View/LevelDesigner/SaveLevelViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelDesigner/SaveLevelViewController.swift
@@ -7,20 +7,31 @@
 
 import UIKit
 
-class SaveLevelViewController: UIViewController {
+class SaveLevelViewController: UIViewController, UITextFieldDelegate {
 
     @IBOutlet private var informationLabel: UILabel!
     @IBOutlet private var levelNameField: UITextField!
     weak var delegate: SaveLevelViewControllerDelegate?
     private var overwrite = false
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        levelNameField.delegate = self
+    }
+    
     @IBAction private func cancelButtonPressed(_ sender: UIButton) {
         dismiss(animated: true)
     }
 
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        overwrite = false
+        informationLabel.text = " "
+        return true
+    }
+
     @IBAction func saveButtonPressed(_ sender: UIButton) {
         guard let levelName = levelNameField.text, !levelName.isEmpty else {
-            informationLabel.text = "PLEASE ENTER A LEVEL NAME"
+            informationLabel.text = "LEVEL NAME CANNOT BE EMPTY"
             return
         }
         do {

--- a/TheAlienThatEatsTheCarrot/View/LevelDesigner/SaveLevelViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelDesigner/SaveLevelViewController.swift
@@ -18,20 +18,36 @@ class SaveLevelViewController: UIViewController, UITextFieldDelegate {
         super.viewDidLoad()
         levelNameField.delegate = self
     }
-    
+
     @IBAction private func cancelButtonPressed(_ sender: UIButton) {
         dismiss(animated: true)
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         overwrite = false
-        informationLabel.text = " "
+
+        guard let text = textField.text,
+              let updatedTextRange = Range(range, in: text) else {
+            return true
+        }
+        let updatedText = text.replacingCharacters(in: updatedTextRange, with: string)
+        let count = updatedText.count
+
+        if count > 15 {
+            informationLabel.text = "LEVEL NAME IS TOO LONG"
+        } else {
+            informationLabel.text = " "
+        }
         return true
     }
 
-    @IBAction func saveButtonPressed(_ sender: UIButton) {
+    @IBAction private func saveButtonPressed(_ sender: UIButton) {
         guard let levelName = levelNameField.text, !levelName.isEmpty else {
             informationLabel.text = "LEVEL NAME CANNOT BE EMPTY"
+            return
+        }
+        if levelName.count > 15 {
+            informationLabel.text = "LEVEL NAME IS TOO LONG"
             return
         }
         do {
@@ -55,7 +71,6 @@ class SaveLevelViewController: UIViewController, UITextFieldDelegate {
         alert.addAction(okAction)
         self.present(alert, animated: true, completion: nil)
     }
-
 }
 
 protocol SaveLevelViewControllerDelegate: AnyObject {

--- a/TheAlienThatEatsTheCarrot/View/LevelSelect/LevelSelectViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/LevelSelect/LevelSelectViewController.swift
@@ -13,10 +13,12 @@ class LevelSelectViewController: UIViewController, LevelViewDelegate {
     @IBOutlet private var stackView: UIStackView!
 
     // Array containing level names
-    let levelNames = ["Level 1", "Level 2", "Level 3", "Level 4", "Level 5"]
+    private var levelNames: [String]!
+    private var storageManager = LevelDataManager()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        levelNames = storageManager.fetchLevelNames()
         initializeLevelDesigner()
     }
 


### PR DESCRIPTION
Saving and loading levels in level designer now works

Saving level: 
- if level name exist, tapping saving twice in a row (without changing the text field) overwrites. 
- level name cannot be empty
- level name cannot be >15 characters long
- TODO: cannot overwrite default levels

Level select page should display all saved level names.