### PR TITLE
Add gravity, fix physics engine

### DIFF
--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/JumpStateComponent.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/JumpStateComponent.swift
@@ -20,4 +20,9 @@ class JumpStateComponent: Component {
         self.maxJump = maxJump
         self.remainingJump = remainingJump
     }
+
+    func setIsGrounded() {
+        isGrounded = true
+        remainingJump = maxJump
+    }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/MovableComponent/Patterns/LeftRightPattern.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/MovableComponent/Patterns/LeftRightPattern.swift
@@ -8,12 +8,16 @@
 import Foundation
 
 class LeftRightPattern: MovementPattern {
-    static let DEFAULT_DISTANCE: CGFloat = 200.0
+    static let DEFAULT_DISTANCE: CGFloat = 400.0
+    static let DEFAULT_VELOCITY = CGVector(dx: 250.0, dy: 0)
+    var velocity: CGVector
     var totalDistanceToMoveBeforeChange: CGFloat
     var distanceMoved: CGFloat = 0
 
-    init(totalDistanceToMoveBeforeChange: CGFloat = LeftRightPattern.DEFAULT_DISTANCE) {
+    init(totalDistanceToMoveBeforeChange: CGFloat = LeftRightPattern.DEFAULT_DISTANCE,
+         velocity: CGVector = LeftRightPattern.DEFAULT_VELOCITY) {
         self.totalDistanceToMoveBeforeChange = totalDistanceToMoveBeforeChange
+        self.velocity = velocity
     }
 
     func move(deltaTime: CGFloat, entity: Entity, delegate: MovableDelegate) {
@@ -22,15 +26,16 @@ class LeftRightPattern: MovementPattern {
             return
         }
         if distanceMoved >= totalDistanceToMoveBeforeChange {
-            changeXDirectionFor(physicsComponent)
+            changeXDirection()
             distanceMoved = 0
             return
         }
-        let horizontalDistanceMoved = physicsComponent.physicsBody.velocity.dx.magnitude * deltaTime
+        let horizontalDistanceMoved = velocity.magnitude * deltaTime
+        physicsComponent.physicsBody.velocity = velocity
         distanceMoved += horizontalDistanceMoved
     }
 
-    private func changeXDirectionFor(_ physicsComponent: PhysicsComponent) {
-        physicsComponent.physicsBody.velocity.dx *= -1
+    private func changeXDirection() {
+        self.velocity.dx *= -1
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PhysicsComponent.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PhysicsComponent.swift
@@ -10,9 +10,11 @@ import Foundation
 class PhysicsComponent: Component {
     var entity: Entity
     var physicsBody: PhysicsBody
+    var disableGravity: Bool
 
-    init(entity: Entity, physicsBody: PhysicsBody) {
+    init(entity: Entity, physicsBody: PhysicsBody, disableGravity: Bool = false) {
         self.entity = entity
         self.physicsBody = physicsBody
+        self.disableGravity = disableGravity
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PlayerComponent.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PlayerComponent.swift
@@ -22,7 +22,7 @@ class PlayerComponent: Component {
 enum ControlAction {
     case idle, jump, left, right
 
-    static let DEFAULT_LEFT_VELOCITY = CGVector(dx: -100.0, dy: 0)
-    static let DEFAULT_RIGHT_VELOCITY = CGVector(dx: 100.0, dy: 0)
-    static let DEFAULT_JUMP_FORCE = CGVector(dx: 0, dy: -10000.0)
+    static let DEFAULT_LEFT_FORCE = CGVector(dx: -1000.0, dy: 0)
+    static let DEFAULT_RIGHT_FORCE = CGVector(dx: 1000.0, dy: 0)
+    static let DEFAULT_JUMP_FORCE = CGVector(dx: 0, dy: -30000.0)
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PlayerComponent.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PlayerComponent.swift
@@ -24,5 +24,5 @@ enum ControlAction {
 
     static let DEFAULT_LEFT_VELOCITY = CGVector(dx: -100.0, dy: 0)
     static let DEFAULT_RIGHT_VELOCITY = CGVector(dx: 100.0, dy: 0)
-    static let DEFAULT_JUMP_FORCE = CGVector(dx: 0, dy: -200000.0)
+    static let DEFAULT_JUMP_FORCE = CGVector(dx: 0, dy: -10000.0)
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/NormalBlockFactory.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/NormalBlockFactory.swift
@@ -9,7 +9,6 @@ import Foundation
 
 class NormalBlockFactory: BlockFactory {
     override func createComponents() -> [Component] {
-        print("creating normal block")
         let size = CGSize(width: boardObject.width, height: boardObject.height)
         let blockComponent = BlockComponent(entity: entity)
         let renderableComponent = RenderableComponent(entity: entity,

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/NormalBlockFactory.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/NormalBlockFactory.swift
@@ -9,12 +9,18 @@ import Foundation
 
 class NormalBlockFactory: BlockFactory {
     override func createComponents() -> [Component] {
+        print("creating normal block")
         let size = CGSize(width: boardObject.width, height: boardObject.height)
         let blockComponent = BlockComponent(entity: entity)
         let renderableComponent = RenderableComponent(entity: entity,
                                                       position: boardObject.position,
                                                       objectType: .block(.normal),
                                                       size: size)
-        return [blockComponent, renderableComponent]
+        let physicsBody = PhysicsBody(shape: .rectangle, position: boardObject.position,
+                                      size: size, categoryBitmask: Constants.blockCategoryBitmask,
+                                      collisionBitmask: Constants.blockCollisionBitmask,
+                                      isDynamic: false)
+        let physicsComponent = PhysicsComponent(entity: entity, physicsBody: physicsBody)
+        return [blockComponent, renderableComponent, physicsComponent]
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/CharacterFactories/NormalCharacterFactory.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/CharacterFactories/NormalCharacterFactory.swift
@@ -14,8 +14,8 @@ class NormalCharacterFactory: CharacterFactory {
         let physicsBody = PhysicsBody(shape: .rectangle,
                                       position: center,
                                       size: size,
-                                      categoryBitmask: Constants.enemyCategoryBitmask,
-                                      collisionBitmask: Constants.enemyCollisionBitmask,
+                                      categoryBitmask: Constants.characterCategoryBitmask,
+                                      collisionBitmask: Constants.characterCollisionBitmask,
                                       isDynamic: true)
         let renderableComponent = RenderableComponent(entity: entity, position: CGPoint(x: 200, y: 200), objectType: .character(.normal))
         let playerComponent = PlayerComponent(entity: entity)

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/CharacterFactories/NormalCharacterFactory.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/CharacterFactories/NormalCharacterFactory.swift
@@ -10,7 +10,7 @@ import Foundation
 class NormalCharacterFactory: CharacterFactory {
     override func createComponents() -> [Component] {
         let center = CGPoint(x: 200.0, y: 200.0)
-        let size = CGSize(width: 100.0, height: 100.0)
+        let size = CGSize(width: 80.0, height: 100.0)
         let physicsBody = PhysicsBody(shape: .rectangle,
                                       position: center,
                                       size: size,

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/EnemyFactories/NormalEnemyFactory.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/EnemyFactories/NormalEnemyFactory.swift
@@ -23,8 +23,8 @@ class NormalEnemyFactory: EnemyFactory {
                                       size: size,
                                       categoryBitmask: Constants.enemyCategoryBitmask,
                                       collisionBitmask: Constants.enemyCollisionBitmask,
-                                      isDynamic: false)
-        physicsBody.velocity = CGVector(dx: 500.0, dy: 0)
+                                      isDynamic: true)
+        physicsBody.velocity = CGVector(dx: 50.0, dy: 0)
         let physicsComponent = PhysicsComponent(entity: entity,
                                                 physicsBody: physicsBody)
         let destroyableComponent = DestroyableComponent(entity: entity)

--- a/TheAlienThatEatsTheCarrot/GameEngine/GameEngine.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/GameEngine.swift
@@ -60,16 +60,20 @@ class GameEngine {
         systems.forEach { $0.update(deltaTime: deltaTime) }
     }
 
+    // Note that PhysicsSystem needs the be at the start, CollisionSystem at the end
+    // This is so that PhysicsSystem can update the positions, and if collision occur
+    // The other systems can handle the side effects (eg. deal damage, add score etc.)
+    // Before the collision is resolved by the CollisionSystem
     private func initGameSystems() {
-        self.systems = [PlayerMovementSystem(nexus: nexus),
+        self.systems = [PhysicsSystem(nexus: nexus, physicsWorld: physicsWorld),
+                        PlayerMovementSystem(nexus: nexus),
                         MovementSystem(nexus: nexus),
                         PlayerPowerupSystem(nexus: nexus),
                         CollectableSystem(nexus: nexus),
                         TimerSystem(nexus: nexus),
                         CameraSystem(nexus: nexus),
                         DamageSystem(nexus: nexus),
-                        CollisionSystem(nexus: nexus, physicsWorld: physicsWorld),
-                        PhysicsSystem(nexus: nexus, physicsWorld: physicsWorld)]
+                        CollisionSystem(nexus: nexus, physicsWorld: physicsWorld)]
     }
 
     private func initGameEntities(from boardObjects: [any BoardObject]) {

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
@@ -17,7 +17,10 @@ final class CollisionSystem: System {
         self.physicsWorld.collisionDelegate = self
     }
 
-    func update(deltaTime: CGFloat) {}
+    func update(deltaTime: CGFloat) {
+        let physicsBodies = nexus.getComponents(of: PhysicsComponent.self).map { $0.physicsBody }
+        physicsWorld.resolveCollisions(for: physicsBodies, deltaTime: deltaTime)
+    }
 
     func lateUpdate(deltaTime: CGFloat) {
         nexus.removeComponents(of: CollisionComponent.self)

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
@@ -101,6 +101,6 @@ extension PhysicsBody {
     static let NEGLIGIBLE_SPEED_THRESHOLD = 60.0
 
     func hasNegligibleYVelocity() -> Bool {
-        return velocity.dy.magnitude < PhysicsBody.NEGLIGIBLE_SPEED_THRESHOLD
+        velocity.dy.magnitude < PhysicsBody.NEGLIGIBLE_SPEED_THRESHOLD
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
@@ -19,44 +19,55 @@ final class CollisionSystem: System {
 
     func update(deltaTime: CGFloat) {
         // Strategy used from https://gamedev.stackexchange.com/questions/16813/handling-collisions-with-ground
-        detectStableGroundCollision()
-        let physicsBodies = nexus.getComponents(of: PhysicsComponent.self).map { $0.physicsBody }
-        physicsWorld.resolveCollisions(for: physicsBodies, deltaTime: deltaTime)
+        let physicsComponentsToDisableGravity = getPhysicsComponentsToDisableGravity()
+        disableGravity(for: physicsComponentsToDisableGravity)
+        let physicsBodiesToDisableGravity = physicsComponentsToDisableGravity.map { $0.physicsBody }
+        let allPhysicsBodies = nexus.getComponents(of: PhysicsComponent.self).map { $0.physicsBody }
+        let physicsBodiesToResolveCollisions = allPhysicsBodies.filter { !physicsBodiesToDisableGravity.contains($0) }
+        physicsWorld.resolveCollisions(for: physicsBodiesToResolveCollisions, deltaTime: deltaTime)
     }
 
     func lateUpdate(deltaTime: CGFloat) {
         nexus.removeComponents(of: CollisionComponent.self)
     }
 
-    private func detectStableGroundCollision() {
+    private func getPhysicsComponentsToDisableGravity() -> [PhysicsComponent] {
+        var toDisable: [PhysicsComponent] = []
         let physicsComponents = nexus.getComponents(of: PhysicsComponent.self)
-        let groundEntities = nexus.getEntities(with: BlockComponent.self)
-        var groundPhysicsComponents: [PhysicsComponent] = []
-        for groundEntity in groundEntities {
-            guard let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: groundEntity) else {
-                continue
-            }
-            groundPhysicsComponents.append(physicsComponent)
+        let groundPhysicsComponents = physicsComponents.filter {
+            nexus.containsComponent(for: $0.entity, of: BlockComponent.self)
         }
-        for physicsComponent in physicsComponents {
-            if nexus.containsComponent(for: physicsComponent.entity, of: BlockComponent.self) {
-                continue
+        let notGroundPhysicsComponents = physicsComponents.filter {
+            !nexus.containsComponent(for: $0.entity, of: BlockComponent.self)
+        }
+        for notGroundPhysicsComponent in notGroundPhysicsComponents {
+            for groundPhysicsComponent in groundPhysicsComponents {
+                if notGroundPhysicsComponent.physicsBody.isCollidingWith(groundPhysicsComponent.physicsBody, on: Direction.up)
+                    && notGroundPhysicsComponent.physicsBody.hasNegligibleYVelocity() {
+                    toDisable.append(notGroundPhysicsComponent)
+                } else if !notGroundPhysicsComponent.physicsBody.hasNegligibleYVelocity() {
+                    restoreGravity(for: notGroundPhysicsComponent)
+                }
             }
-            handleCollisionWithGround(for: physicsComponent, groundPhysicsComponents: groundPhysicsComponents)
+        }
+        return toDisable
+    }
+
+    private func disableGravity(for physicsComponents: [PhysicsComponent]) {
+        for physicsComponent in physicsComponents {
+            if let jumpComponent = nexus.getComponent(of: JumpStateComponent.self, for: physicsComponent.entity) {
+                jumpComponent.setIsGrounded()
+            }
+            physicsComponent.physicsBody.velocity.dy = 0
+            physicsComponent.disableGravity = true
         }
     }
 
-    private func handleCollisionWithGround(for physicsComponent: PhysicsComponent, groundPhysicsComponents: [PhysicsComponent]) {
-        for groundPhysicsComponent in groundPhysicsComponents {
-            if !physicsComponent.physicsBody.hasNegligibleYVelocity() {
-                physicsComponent.disableGravity = false
-            }
-            if physicsComponent.physicsBody.isCollidingWith(groundPhysicsComponent.physicsBody, on: Direction.up)
-                && physicsComponent.physicsBody.hasNegligibleYVelocity() {
-                physicsComponent.physicsBody.velocity.dy = 0
-                physicsComponent.disableGravity = true
-            }
+    private func restoreGravity(for physicsComponent: PhysicsComponent) {
+        if let jumpComponent = nexus.getComponent(of: JumpStateComponent.self, for: physicsComponent.entity) {
+            jumpComponent.isGrounded = false
         }
+        physicsComponent.disableGravity = false
     }
 }
 
@@ -89,6 +100,6 @@ extension PhysicsBody {
     static let NEGLIGIBLE_SPEED_THRESHOLD = 60.0
 
     func hasNegligibleYVelocity() -> Bool {
-        velocity.dy.magnitude < PhysicsBody.NEGLIGIBLE_SPEED_THRESHOLD
+        return velocity.dy.magnitude < PhysicsBody.NEGLIGIBLE_SPEED_THRESHOLD
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
@@ -18,12 +18,45 @@ final class CollisionSystem: System {
     }
 
     func update(deltaTime: CGFloat) {
+        // Strategy used from https://gamedev.stackexchange.com/questions/16813/handling-collisions-with-ground
+        detectStableGroundCollision()
         let physicsBodies = nexus.getComponents(of: PhysicsComponent.self).map { $0.physicsBody }
         physicsWorld.resolveCollisions(for: physicsBodies, deltaTime: deltaTime)
     }
 
     func lateUpdate(deltaTime: CGFloat) {
         nexus.removeComponents(of: CollisionComponent.self)
+    }
+
+    private func detectStableGroundCollision() {
+        let physicsComponents = nexus.getComponents(of: PhysicsComponent.self)
+        let groundEntities = nexus.getEntities(with: BlockComponent.self)
+        var groundPhysicsComponents: [PhysicsComponent] = []
+        for groundEntity in groundEntities {
+            guard let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: groundEntity) else {
+                continue
+            }
+            groundPhysicsComponents.append(physicsComponent)
+        }
+        for physicsComponent in physicsComponents {
+            if nexus.containsComponent(for: physicsComponent.entity, of: BlockComponent.self) {
+                continue
+            }
+            handleCollisionWithGround(for: physicsComponent, groundPhysicsComponents: groundPhysicsComponents)
+        }
+    }
+
+    private func handleCollisionWithGround(for physicsComponent: PhysicsComponent, groundPhysicsComponents: [PhysicsComponent]) {
+        for groundPhysicsComponent in groundPhysicsComponents {
+            if !physicsComponent.physicsBody.hasNegligibleYVelocity() {
+                physicsComponent.disableGravity = false
+            }
+            if physicsComponent.physicsBody.isCollidingWith(groundPhysicsComponent.physicsBody, on: Direction.up)
+                && physicsComponent.physicsBody.hasNegligibleYVelocity() {
+                physicsComponent.physicsBody.velocity.dy = 0
+                physicsComponent.disableGravity = true
+            }
+        }
     }
 }
 
@@ -49,5 +82,13 @@ extension CollisionSystem: PhysicsCollisionDelegate {
         let physicsComponent = physicsComponents.first(where: { $0.physicsBody === physicsBody })
 
         return physicsComponent?.entity
+    }
+}
+
+extension PhysicsBody {
+    static let NEGLIGIBLE_SPEED_THRESHOLD = 60.0
+
+    func hasNegligibleYVelocity() -> Bool {
+        velocity.dy.magnitude < PhysicsBody.NEGLIGIBLE_SPEED_THRESHOLD
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
@@ -31,7 +31,7 @@ final class PhysicsSystem: System {
 
     private func updatePhysicsBodies(deltaTime: CGFloat) {
         let physicsBodies = nexus.getComponents(of: PhysicsComponent.self).map { $0.physicsBody }
-        physicsWorld.update(physicsBodies, deltaTime: deltaTime)
+        physicsWorld.updatePhysicsBodies(physicsBodies, deltaTime: deltaTime)
     }
 
     private func updateRenderable(_ entity: Entity) {

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
@@ -26,6 +26,7 @@ final class PhysicsSystem: System {
         }
 
         updatePhysicsBodies(deltaTime: deltaTime)
+        nexus.removeComponents(of: CollisionComponent.self)
     }
 
     private func updatePhysicsBodies(deltaTime: CGFloat) {

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
@@ -8,6 +8,7 @@
 import CoreGraphics
 
 final class PhysicsSystem: System {
+    static let GRAVITY_FORCE = CGVector(dx: 0, dy: 200.0)
     let nexus: Nexus
     let physicsWorld: PhysicsWorld
 
@@ -21,12 +22,11 @@ final class PhysicsSystem: System {
 
         entities.forEach { entity in
             updateRenderable(entity)
+            applyGravityTo(entity)
         }
 
         updatePhysicsBodies(deltaTime: deltaTime)
     }
-
-    func lateUpdate(deltaTime: CGFloat) {}
 
     private func updatePhysicsBodies(deltaTime: CGFloat) {
         let physicsBodies = nexus.getComponents(of: PhysicsComponent.self).map { $0.physicsBody }
@@ -40,5 +40,12 @@ final class PhysicsSystem: System {
             return
         }
         renderableComponent.position = physicsComponent.physicsBody.position
+    }
+
+    private func applyGravityTo(_ entity: Entity) {
+        guard let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: entity) else {
+            return
+        }
+        physicsComponent.physicsBody.applyForce(PhysicsSystem.GRAVITY_FORCE)
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
@@ -50,6 +50,9 @@ final class PhysicsSystem: System {
         guard let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: entity) else {
             return
         }
+        if physicsComponent.disableGravity {
+            return
+        }
         physicsComponent.physicsBody.applyForce(PhysicsSystem.GRAVITY_FORCE)
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
@@ -8,7 +8,7 @@
 import CoreGraphics
 
 final class PhysicsSystem: System {
-    static let GRAVITY_FORCE = CGVector(dx: 0, dy: 200.0)
+    static let GRAVITY_FORCE = CGVector(dx: 0, dy: 1000.0)
     let nexus: Nexus
     let physicsWorld: PhysicsWorld
 
@@ -43,6 +43,9 @@ final class PhysicsSystem: System {
     }
 
     private func applyGravityTo(_ entity: Entity) {
+        if !nexus.containsAnyComponent(of: [PlayerComponent.self, EnemyComponent.self], in: entity) {
+            return
+        }
         guard let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: entity) else {
             return
         }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
@@ -69,9 +69,9 @@ class PlayerMovementSystem: System {
         case .jump:
             jumpIfPlayerHasJumpsAvailable(for: player)
         case .left:
-            setVelocity(for: player, velocity: ControlAction.DEFAULT_LEFT_VELOCITY)
+            addHorizontalForce(for: player, force: ControlAction.DEFAULT_LEFT_FORCE)
         case .right:
-            setVelocity(for: player, velocity: ControlAction.DEFAULT_RIGHT_VELOCITY)
+            addHorizontalForce(for: player, force: ControlAction.DEFAULT_RIGHT_FORCE)
         }
     }
 
@@ -107,14 +107,14 @@ class PlayerMovementSystem: System {
         }
     }
 
-    private func setVelocity(for player: PlayerComponent, velocity: CGVector) {
+    private func addHorizontalForce(for player: PlayerComponent, force: CGVector) {
         guard
             let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: player.entity),
             let jumpStateComponent = nexus.getComponent(of: JumpStateComponent.self, for: player.entity) else {
             return
         }
         if jumpStateComponent.isGrounded {
-            physicsComponent.physicsBody.velocity = velocity
+            physicsComponent.physicsBody.applyForce(force)
         }
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
@@ -65,7 +65,7 @@ class PlayerMovementSystem: System {
     private func applyPhysicsBasedOnControlAction(for player: PlayerComponent) {
         switch player.action {
         case .idle:
-            resetVelocityToZeroIfGrounded(for: player)
+            doNothing()
         case .jump:
             jumpIfPlayerHasJumpsAvailable(for: player)
         case .left:
@@ -91,14 +91,8 @@ class PlayerMovementSystem: System {
         camera.updateCameraBoundsFromCenter(center: renderableComponent.position)
     }
 
-    private func resetVelocityToZeroIfGrounded(for player: PlayerComponent) {
-        guard let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: player.entity),
-              let jumpStateComponent = nexus.getComponent(of: JumpStateComponent.self, for: player.entity) else {
-            return
-        }
-        if jumpStateComponent.isGrounded {
-            physicsComponent.physicsBody.velocity = .zero
-        }
+    private func doNothing() {
+        // do nothing
     }
 
     private func jumpIfPlayerHasJumpsAvailable(for player: PlayerComponent) {

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
@@ -105,7 +105,8 @@ class PlayerMovementSystem: System {
         }
         if jumpStateComponent.remainingJump > 0 {
             physicsComponent.physicsBody.applyForce(ControlAction.DEFAULT_JUMP_FORCE)
-            jumpStateComponent.isGrounded = false
+            // TODO: uncomment this code once we set isGrounded to true when player collides with other physics object
+            // jumpStateComponent.isGrounded = false
             jumpStateComponent.remainingJump -= 1
         }
     }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
@@ -52,7 +52,9 @@ class PlayerMovementSystem: System {
     }
 
     private func updateJumpState(for player: PlayerComponent) {
-        guard let jumpStateComponent = nexus.getComponent(of: JumpStateComponent.self, for: player.entity) else {
+        guard
+            let jumpStateComponent = nexus.getComponent(of: JumpStateComponent.self, for: player.entity),
+            let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: player.entity) else {
             return
         }
         // TODO: add a system that modifies canJump if the player is standing on an object
@@ -103,6 +105,7 @@ class PlayerMovementSystem: System {
         }
         if jumpStateComponent.remainingJump > 0 {
             physicsComponent.physicsBody.applyForce(ControlAction.DEFAULT_JUMP_FORCE)
+            jumpStateComponent.isGrounded = false
             jumpStateComponent.remainingJump -= 1
         }
     }

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
@@ -68,9 +68,6 @@ final class PhysicsBody {
 
     func update(deltaTime: CGFloat) {
         let maxSpeed = PhysicsConstants.maxSpeed
-        if netForce != .zero {
-            print("net force \(netForce)")
-        }
         velocity += netForce / mass * deltaTime
         if velocity.magnitude > maxSpeed {
             velocity = velocity.unitVector * maxSpeed

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
@@ -98,15 +98,6 @@ extension PhysicsBody {
         }
         let collisionAngle = collisionPoints.normal.angle
         var angleInDegrees = (collisionAngle * 180 / Double.pi).truncatingRemainder(dividingBy: 360)
-        if (-135...(-45)).contains(angleInDegrees) {
-            print("up")
-        } else if (45...135).contains(angleInDegrees) {
-            print("down")
-        } else if (135...180).contains(angleInDegrees) || (-180...(-135)).contains(angleInDegrees) {
-            print("left")
-        } else if (-45...45).contains(angleInDegrees) {
-            print("right")
-        }
         switch direction {
         case .up:
             return (-135...(-45)).contains(angleInDegrees)

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
@@ -72,7 +72,6 @@ final class PhysicsBody {
             print("net force \(netForce)")
         }
         velocity += netForce / mass * deltaTime
-        print("velocity magnitude: \(velocity.magnitude) max speed: \(maxSpeed)")
         if velocity.magnitude > maxSpeed {
             velocity = velocity.unitVector * maxSpeed
         }

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
@@ -96,18 +96,28 @@ extension PhysicsBody {
         if !collisionPoints.hasCollision {
             return false
         }
-        let collisionNormal = self.position - other.position
+        let collisionNormal = collisionPoints.normal
         let collisionAngle = collisionNormal.angle
         var angleInDegrees = (collisionAngle * 180 / Double.pi).truncatingRemainder(dividingBy: 360)
+        print("Angle \(angleInDegrees)")
+        if (-135...(-45)).contains(angleInDegrees) {
+            print("up")
+        } else if (45...135).contains(angleInDegrees) {
+            print("down")
+        } else if (135...180).contains(angleInDegrees) || (-180...(-135)).contains(angleInDegrees) {
+            print("left")
+        } else if (-45...45).contains(angleInDegrees) {
+            print("right")
+        }
         switch direction {
         case .up:
-            return 225 <= angleInDegrees && angleInDegrees <= 315
+            return (-135...(-45)).contains(angleInDegrees)
         case .down:
-            return 45 <= angleInDegrees && angleInDegrees <= 135
+            return (45...135).contains(angleInDegrees)
         case .left:
-            return 135 <= angleInDegrees && angleInDegrees <= 225
+            return (135...180).contains(angleInDegrees) || (-180...(-135)).contains(angleInDegrees)
         case .right:
-            return angleInDegrees <= 45 || angleInDegrees >= 315
+            return (-45...45).contains(angleInDegrees)
         default:
             return false
         }

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
@@ -96,10 +96,8 @@ extension PhysicsBody {
         if !collisionPoints.hasCollision {
             return false
         }
-        let collisionNormal = collisionPoints.normal
-        let collisionAngle = collisionNormal.angle
+        let collisionAngle = collisionPoints.normal.angle
         var angleInDegrees = (collisionAngle * 180 / Double.pi).truncatingRemainder(dividingBy: 360)
-        print("Angle \(angleInDegrees)")
         if (-135...(-45)).contains(angleInDegrees) {
             print("up")
         } else if (45...135).contains(angleInDegrees) {

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsWorld.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsWorld.swift
@@ -21,7 +21,7 @@ final class PhysicsWorld {
         resolveCollisions(for: physicsBodies, deltaTime: deltaTime)
     }
 
-    private func updatePhysicsBodies(_ physicsBodies: [PhysicsBody],
+    func updatePhysicsBodies(_ physicsBodies: [PhysicsBody],
                                      deltaTime: CGFloat) {
         for physicsBody in physicsBodies {
             physicsBody.update(deltaTime: deltaTime)
@@ -93,7 +93,7 @@ final class PhysicsWorld {
         || (bodyA.categoryBitmask & bodyB.collisionBitmask != .zero)
     }
 
-    private func resolveCollisions(for physicsBodies: [PhysicsBody], deltaTime: CGFloat) {
+    func resolveCollisions(for physicsBodies: [PhysicsBody], deltaTime: CGFloat) {
         let collisions = detectCollisions(for: physicsBodies)
 
         for collision in collisions {

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsWorld.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsWorld.swift
@@ -127,7 +127,7 @@ final class PhysicsWorld {
                                   depth: CGFloat,
                                   deltaTime: CGFloat) {
         // Decouple physics bodies
-        dynamicBody.position += normal * depth
+        dynamicBody.position += normal
 
         // Resolve velocity
         guard dynamicBody.restitution != .zero else {

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsWorld.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsWorld.swift
@@ -28,7 +28,7 @@ final class PhysicsWorld {
         }
     }
 
-    private func detectCollisions(for physicsBodies: [PhysicsBody]) -> Set<Collision> {
+    private func detectCollisions(for physicsBodies: [PhysicsBody], toIgnore: Set<[PhysicsBody]>) -> Set<Collision> {
         var currentCollisions: Set<Collision> = []
 
         guard physicsBodies.count >= 2 else {
@@ -41,7 +41,7 @@ final class PhysicsWorld {
                 let bodyA = physicsBodies[i]
                 let bodyB = physicsBodies[j]
 
-                if !canCollide(bodyA, bodyB) {
+                if !canCollide(bodyA, bodyB) || toBeIgnored(bodyA, bodyB, toIgnore: toIgnore) {
                     continue
                 }
 
@@ -56,6 +56,10 @@ final class PhysicsWorld {
         publishCollisions(currentCollisions)
 
         return currentCollisions
+    }
+
+    private func toBeIgnored(_ bodyA: PhysicsBody, _ bodyB: PhysicsBody, toIgnore: Set<[PhysicsBody]>) -> Bool {
+        return toIgnore.contains([bodyA, bodyB]) || toIgnore.contains([bodyB, bodyA])
     }
 
     private func publishCollisions(_ currentCollisions: Set<Collision>) {
@@ -93,8 +97,8 @@ final class PhysicsWorld {
         || (bodyA.categoryBitmask & bodyB.collisionBitmask != .zero)
     }
 
-    func resolveCollisions(for physicsBodies: [PhysicsBody], deltaTime: CGFloat) {
-        let collisions = detectCollisions(for: physicsBodies)
+    func resolveCollisions(for physicsBodies: [PhysicsBody], deltaTime: CGFloat, toIgnore: Set<[PhysicsBody]> = Set()) {
+        let collisions = detectCollisions(for: physicsBodies, toIgnore: toIgnore)
 
         for collision in collisions {
             guard [collision.bodyA, collision.bodyB].allSatisfy({ $0.isTrigger == false }) else {

--- a/TheAlienThatEatsTheCarrot/Utilities/Constants.swift
+++ b/TheAlienThatEatsTheCarrot/Utilities/Constants.swift
@@ -20,7 +20,7 @@ struct Constants {
 
     // Collision Bitmasks
     static let characterCollisionBitmask: UInt32 = enemyCategoryBitmask | blockCategoryBitmask
-    static let enemyCollisionBitmask: UInt32 = characterCategoryBitmask
+    static let enemyCollisionBitmask: UInt32 = characterCategoryBitmask | blockCategoryBitmask
     static let blockCollisionBitmask: UInt32 = characterCategoryBitmask
     static let powerupCollisionBitmask: UInt32 = 0
     static let collectibleCollisionBitmask: UInt32 = 0

--- a/TheAlienThatEatsTheCarrot/Utilities/Constants.swift
+++ b/TheAlienThatEatsTheCarrot/Utilities/Constants.swift
@@ -15,8 +15,8 @@ struct Constants {
     static let characterCategoryBitmask: UInt32 = 1 << 0
     static let enemyCategoryBitmask: UInt32 = 1 << 1
     static let blockCategoryBitmask: UInt32 = 1 << 2
-    static let powerupCategortBitmask: UInt32 = 1 << 3
-    static let collectableCategortBitmask: UInt32 = 1 << 4
+    static let powerupCategoryBitmask: UInt32 = 1 << 3
+    static let collectableCategoryBitmask: UInt32 = 1 << 4
 
     // Collision Bitmasks
     static let characterCollisionBitmask: UInt32 = enemyCategoryBitmask | blockCategoryBitmask

--- a/TheAlienThatEatsTheCarrot/View/GamePlay/GamePlayViewController.swift
+++ b/TheAlienThatEatsTheCarrot/View/GamePlay/GamePlayViewController.swift
@@ -62,6 +62,7 @@ class GamePlayViewController: UIViewController {
             return
         }
         gameLoop.stop()
+        isGameLoopRunning = false
     }
 
     private func updateUI() {
@@ -69,7 +70,7 @@ class GamePlayViewController: UIViewController {
         // if you want to remove image indiviudally call `removeImage(id: ObjectIdentifier(component))`
         renderableComponents = gameEngine.getRenderableComponents()
         gameStats = gameEngine.getGameStats()
-        
+
         for component in renderableComponents {
             addImage(id: ObjectIdentifier(component), objectType: component.objectType, center: component.position, width: component.size.width, height: component.size.height)
         }


### PR DESCRIPTION
In response to the comment [here](https://github.com/cs3217-2324/group-project-the-alien-that-eats-the-carrot/pull/40#discussion_r1548842641), I think physics should be handled in physics system, since it contains game specific logic (eg. only apply physics to players and enemies even though blocks contain physics component).


I have separated the logic in physics system and collision system. This is resolve a bug that I faced. Calling the `isColliding` function will never evaluate to true even if the items look like they are colliding. This is because everytime the position is updated in the `PhysicsSystem`, if there is a collision, it is resolved immediately.

To fix this, I separated the logic for updating position and resolving collision, and put PhysicsSystem before any other systems, and left CollisionSystem as the last to update. As such, when there is a collision, the other systems can handle their respective side effect before the collisions are ultimately resolved by CollisionSystem.


Lastly, I notice that the degree starts counting from East. Eg. if I collide from the right hand side it is 180 degree (or -180 degree). The program also uses angles between the range of -180 and 180, which is why i updated the physics body.