### PR TITLE
Improve game engine (melee cooldown, set attack directions, spikeblocks, pushableblocks)

### DIFF
--- a/TheAlienThatEatsTheCarrot.xcodeproj/project.pbxproj
+++ b/TheAlienThatEatsTheCarrot.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		0AC8612B2BBC04E40060EF90 /* GameStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC8612A2BBC04E40060EF90 /* GameStats.swift */; };
 		0AC8612D2BBC05D40060EF90 /* GameEngine+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC8612C2BBC05D40060EF90 /* GameEngine+Extensions.swift */; };
 		0AC8612F2BBC25150060EF90 /* FastEnemyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC8612E2BBC25150060EF90 /* FastEnemyFactory.swift */; };
+		0AC861352BBF26720060EF90 /* MeleeFinishCooldownEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC861342BBF26720060EF90 /* MeleeFinishCooldownEvent.swift */; };
 		3F462ED52BAFDA350049F71A /* LevelDesignerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F462ED42BAFDA350049F71A /* LevelDesignerViewController.swift */; };
 		3F6807692BADAF9D00EB7682 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F8C57EE2BAAD71B002E75FB /* Assets.xcassets */; };
 		3F68076B2BADB18C00EB7682 /* LevelSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F68076A2BADB18C00EB7682 /* LevelSelectViewController.swift */; };
@@ -225,6 +226,7 @@
 		0AC8612A2BBC04E40060EF90 /* GameStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameStats.swift; sourceTree = "<group>"; };
 		0AC8612C2BBC05D40060EF90 /* GameEngine+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GameEngine+Extensions.swift"; sourceTree = "<group>"; };
 		0AC8612E2BBC25150060EF90 /* FastEnemyFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastEnemyFactory.swift; sourceTree = "<group>"; };
+		0AC861342BBF26720060EF90 /* MeleeFinishCooldownEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeleeFinishCooldownEvent.swift; sourceTree = "<group>"; };
 		3F462ED42BAFDA350049F71A /* LevelDesignerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelDesignerViewController.swift; sourceTree = "<group>"; };
 		3F68076A2BADB18C00EB7682 /* LevelSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelSelectViewController.swift; sourceTree = "<group>"; };
 		3F68076C2BADBCD200EB7682 /* LevelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelView.swift; sourceTree = "<group>"; };
@@ -357,6 +359,7 @@
 				0AC860B62BB3D3550060EF90 /* PlayerControlActionEvent.swift */,
 				0AC860D72BB6B0750060EF90 /* PowerupElapseEvent.swift */,
 				0AC860E72BB7BC170060EF90 /* DestroyEvent.swift */,
+				0AC861342BBF26720060EF90 /* MeleeFinishCooldownEvent.swift */,
 				0AC8611D2BB93B2A0060EF90 /* AddScoreEvent.swift */,
 			);
 			path = GameEvents;
@@ -1059,6 +1062,7 @@
 				3F68076D2BADBCD200EB7682 /* LevelView.swift in Sources */,
 				0AC860DA2BB6D7F90060EF90 /* TimerSystem.swift in Sources */,
 				3FCD005B2BB005340016389F /* CollectiblesViewController.swift in Sources */,
+				0AC861352BBF26720060EF90 /* MeleeFinishCooldownEvent.swift in Sources */,
 				9F9D15F52BBC29CF005D1985 /* CollisionComponent.swift in Sources */,
 				0AC860B22BB3A5360060EF90 /* GameStartEvent.swift in Sources */,
 				0AC860EC2BB7C2810060EF90 /* InventoryComponent.swift in Sources */,

--- a/TheAlienThatEatsTheCarrot.xcodeproj/project.pbxproj
+++ b/TheAlienThatEatsTheCarrot.xcodeproj/project.pbxproj
@@ -108,6 +108,8 @@
 		0AC8612F2BBC25150060EF90 /* FastEnemyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC8612E2BBC25150060EF90 /* FastEnemyFactory.swift */; };
 		0AC861352BBF26720060EF90 /* MeleeFinishCooldownEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC861342BBF26720060EF90 /* MeleeFinishCooldownEvent.swift */; };
 		0AC861372BBFB4DB0060EF90 /* SpikeBlockFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC861362BBFB4DB0060EF90 /* SpikeBlockFactory.swift */; };
+		0AC861392BBFBE0A0060EF90 /* PushableBlockFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC861382BBFBE0A0060EF90 /* PushableBlockFactory.swift */; };
+		0AC8613B2BBFC3D60060EF90 /* MoveWhenPushedPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC8613A2BBFC3D60060EF90 /* MoveWhenPushedPattern.swift */; };
 		3F462ED52BAFDA350049F71A /* LevelDesignerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F462ED42BAFDA350049F71A /* LevelDesignerViewController.swift */; };
 		3F6807692BADAF9D00EB7682 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F8C57EE2BAAD71B002E75FB /* Assets.xcassets */; };
 		3F68076B2BADB18C00EB7682 /* LevelSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F68076A2BADB18C00EB7682 /* LevelSelectViewController.swift */; };
@@ -229,6 +231,8 @@
 		0AC8612E2BBC25150060EF90 /* FastEnemyFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastEnemyFactory.swift; sourceTree = "<group>"; };
 		0AC861342BBF26720060EF90 /* MeleeFinishCooldownEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeleeFinishCooldownEvent.swift; sourceTree = "<group>"; };
 		0AC861362BBFB4DB0060EF90 /* SpikeBlockFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpikeBlockFactory.swift; sourceTree = "<group>"; };
+		0AC861382BBFBE0A0060EF90 /* PushableBlockFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushableBlockFactory.swift; sourceTree = "<group>"; };
+		0AC8613A2BBFC3D60060EF90 /* MoveWhenPushedPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveWhenPushedPattern.swift; sourceTree = "<group>"; };
 		3F462ED42BAFDA350049F71A /* LevelDesignerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelDesignerViewController.swift; sourceTree = "<group>"; };
 		3F68076A2BADB18C00EB7682 /* LevelSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelSelectViewController.swift; sourceTree = "<group>"; };
 		3F68076C2BADBCD200EB7682 /* LevelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelView.swift; sourceTree = "<group>"; };
@@ -383,6 +387,7 @@
 				0AC860BC2BB67F900060EF90 /* NormalBlockFactory.swift */,
 				0AC860BE2BB67FB30060EF90 /* GroundBlockFactory.swift */,
 				0AC861362BBFB4DB0060EF90 /* SpikeBlockFactory.swift */,
+				0AC861382BBFBE0A0060EF90 /* PushableBlockFactory.swift */,
 			);
 			path = BlockFactories;
 			sourceTree = "<group>";
@@ -453,6 +458,7 @@
 			children = (
 				0AC860E12BB71CA60060EF90 /* LeftRightPattern.swift */,
 				0AC861152BB8FDDB0060EF90 /* RandomPattern.swift */,
+				0AC8613A2BBFC3D60060EF90 /* MoveWhenPushedPattern.swift */,
 			);
 			path = Patterns;
 			sourceTree = "<group>";
@@ -941,6 +947,7 @@
 				0A76A4712BAC78470067BD6E /* ComponentIdentifier.swift in Sources */,
 				3F68076B2BADB18C00EB7682 /* LevelSelectViewController.swift in Sources */,
 				0AC861002BB7E9620060EF90 /* DoubleJumpPowerupFactory.swift in Sources */,
+				0AC861392BBFBE0A0060EF90 /* PushableBlockFactory.swift in Sources */,
 				0AC860E22BB71CA60060EF90 /* LeftRightPattern.swift in Sources */,
 				3FE4570D2BADAB8E00D8D5A9 /* StartScreenViewController.swift in Sources */,
 				0AC860F22BB7C5110060EF90 /* GameCollectable.swift in Sources */,
@@ -1007,6 +1014,7 @@
 				0A76A4A52BAD22C50067BD6E /* EnemyFactory.swift in Sources */,
 				0A76A49A2BAC78960067BD6E /* DestroyableComponent.swift in Sources */,
 				0AC860EE2BB7C3150060EF90 /* CollectableSystem.swift in Sources */,
+				0AC8613B2BBFC3D60060EF90 /* MoveWhenPushedPattern.swift in Sources */,
 				0A76A4B12BAD54C60067BD6E /* GameRenderer.swift in Sources */,
 				9F8C58A72BAE9A51002E75FB /* CollectableType.swift in Sources */,
 				9F8C58C52BAEBAA3002E75FB /* Level.swift in Sources */,

--- a/TheAlienThatEatsTheCarrot.xcodeproj/project.pbxproj
+++ b/TheAlienThatEatsTheCarrot.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		0AC8612D2BBC05D40060EF90 /* GameEngine+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC8612C2BBC05D40060EF90 /* GameEngine+Extensions.swift */; };
 		0AC8612F2BBC25150060EF90 /* FastEnemyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC8612E2BBC25150060EF90 /* FastEnemyFactory.swift */; };
 		0AC861352BBF26720060EF90 /* MeleeFinishCooldownEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC861342BBF26720060EF90 /* MeleeFinishCooldownEvent.swift */; };
+		0AC861372BBFB4DB0060EF90 /* SpikeBlockFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC861362BBFB4DB0060EF90 /* SpikeBlockFactory.swift */; };
 		3F462ED52BAFDA350049F71A /* LevelDesignerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F462ED42BAFDA350049F71A /* LevelDesignerViewController.swift */; };
 		3F6807692BADAF9D00EB7682 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F8C57EE2BAAD71B002E75FB /* Assets.xcassets */; };
 		3F68076B2BADB18C00EB7682 /* LevelSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F68076A2BADB18C00EB7682 /* LevelSelectViewController.swift */; };
@@ -227,6 +228,7 @@
 		0AC8612C2BBC05D40060EF90 /* GameEngine+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GameEngine+Extensions.swift"; sourceTree = "<group>"; };
 		0AC8612E2BBC25150060EF90 /* FastEnemyFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastEnemyFactory.swift; sourceTree = "<group>"; };
 		0AC861342BBF26720060EF90 /* MeleeFinishCooldownEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeleeFinishCooldownEvent.swift; sourceTree = "<group>"; };
+		0AC861362BBFB4DB0060EF90 /* SpikeBlockFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpikeBlockFactory.swift; sourceTree = "<group>"; };
 		3F462ED42BAFDA350049F71A /* LevelDesignerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelDesignerViewController.swift; sourceTree = "<group>"; };
 		3F68076A2BADB18C00EB7682 /* LevelSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelSelectViewController.swift; sourceTree = "<group>"; };
 		3F68076C2BADBCD200EB7682 /* LevelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelView.swift; sourceTree = "<group>"; };
@@ -380,6 +382,7 @@
 			children = (
 				0AC860BC2BB67F900060EF90 /* NormalBlockFactory.swift */,
 				0AC860BE2BB67FB30060EF90 /* GroundBlockFactory.swift */,
+				0AC861362BBFB4DB0060EF90 /* SpikeBlockFactory.swift */,
 			);
 			path = BlockFactories;
 			sourceTree = "<group>";
@@ -1032,6 +1035,7 @@
 				0AC861102BB868D70060EF90 /* AttackStyle.swift in Sources */,
 				0AC860DC2BB7144C0060EF90 /* InvinsibleGamePowerup.swift in Sources */,
 				3FCD00592BB0050D0016389F /* PowerupsViewController.swift in Sources */,
+				0AC861372BBFB4DB0060EF90 /* SpikeBlockFactory.swift in Sources */,
 				0A76A4682BAC78200067BD6E /* GameLoop.swift in Sources */,
 				9F9D15F72BBC2A15005D1985 /* Constants.swift in Sources */,
 				0A76A4D22BAF23900067BD6E /* PhysicsComponent.swift in Sources */,

--- a/TheAlienThatEatsTheCarrot/Events/GameEvents/MeleeFinishCooldownEvent.swift
+++ b/TheAlienThatEatsTheCarrot/Events/GameEvents/MeleeFinishCooldownEvent.swift
@@ -1,0 +1,21 @@
+//
+//  MeleeFinishCooldownEvent.swift
+//  TheAlienThatEatsTheCarrot
+//
+//  Created by Justin Cheah Yun Fei on 5/4/24.
+//
+
+import Foundation
+
+class MeleeFinishCooldownEvent: Event {
+    static var name: Notification.Name = .meleeFinishCooldown
+    let meleeAttackStyle: MeleeAttackStyle
+
+    init(meleeAttackStyle: MeleeAttackStyle) {
+        self.meleeAttackStyle = meleeAttackStyle
+    }
+}
+
+extension Notification.Name {
+    static let meleeFinishCooldown = Notification.Name("meleeFinishCooldown")
+}

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/JumpAttackStyle.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/JumpAttackStyle.swift
@@ -25,6 +25,6 @@ class JumpAttackStyle: AttackStyle {
     }
 
     private func isAttackerJumpingOnAttackee(attacker: PhysicsBody, attackee: PhysicsBody) -> Bool {
-        attacker.isCollidingWith(attackee, on: .up)
+        attacker.isCollidingWith(attackee, on: .up) && !attacker.hasNegligibleYVelocity()
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
@@ -93,15 +93,15 @@ extension Direction {
     var vectorAngle: CGFloat {
         switch self {
         case .left:
-            0
+            return 0
         case .right:
-            CGFloat.pi
+            return CGFloat.pi
         case .up:
-            CGFloat.pi / 2
+            return CGFloat.pi / 2
         case .down:
-            3 * CGFloat.pi / 2
+            return 3 * CGFloat.pi / 2
         default:
-            0
+            return 0
         }
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
@@ -93,9 +93,16 @@ class MeleeAttackStyle: AttackStyle {
 extension Direction {
     var vectorAngle: CGFloat {
         switch self {
-        case .left: return 0
-        case .right: return CGFloat.pi
-        default: return 0
+        case .left:
+            0
+        case .right:
+            CGFloat.pi
+        case .up:
+            CGFloat.pi / 2
+        case .down:
+            3 * CGFloat.pi / 2
+        default:
+            0
         }
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
@@ -9,10 +9,10 @@ import Foundation
 
 class MeleeAttackStyle: AttackStyle {
     static let DEFAULT_COOLDOWN_DURATION = 0.3
-    static let DEFAULT_KNOCKBACK_STRENGTH = 10000.0
+    static let DEFAULT_KNOCKBACK_STRENGTH = 10_000.0
     let acceptableAttackDirections: [Direction]
     var knockbackStrength: CGFloat
-    var isCoolingDown: Bool = false
+    var isCoolingDown = false
     var coolDownDuration: CGFloat
     private var meleeFinishCooldownObserver: NSObjectProtocol?
 

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
@@ -9,17 +9,18 @@ import Foundation
 
 class MeleeAttackStyle: AttackStyle {
     static let DEFAULT_COOLDOWN_DURATION = 0.3
+    static let DEFAULT_KNOCKBACK_STRENGTH = 10000.0
     let acceptableAttackDirections: [Direction]
-    var knockbackForce: CGFloat
+    var knockbackStrength: CGFloat
     var isCoolingDown: Bool = false
     var coolDownDuration: CGFloat
     private var meleeFinishCooldownObserver: NSObjectProtocol?
 
     init(acceptableAttackDirections: [Direction] = [.left, .right],
-         knockbackForce: CGFloat = 1000.0,
+         knockbackStrength: CGFloat = MeleeAttackStyle.DEFAULT_KNOCKBACK_STRENGTH,
          cooldownDuration: CGFloat = MeleeAttackStyle.DEFAULT_COOLDOWN_DURATION) {
         self.acceptableAttackDirections = acceptableAttackDirections
-        self.knockbackForce = knockbackForce
+        self.knockbackStrength = knockbackStrength
         self.coolDownDuration = cooldownDuration
         subscribeToEvents()
     }
@@ -35,14 +36,12 @@ class MeleeAttackStyle: AttackStyle {
         if attacker != attackee
             && canAttack(attackee, with: targetables, using: delegate)
             && !isCoolingDown {
-            
-            for direction in acceptableAttackDirections {
-                if isAttacker(attacker, attacking: attackee, from: direction, delegate: delegate) {
-                    dealDamage(damage, to: attackee, delegate: delegate)
-                    applyKnockback(from: attacker, to: attackee, direction: direction, delegate: delegate)
-                    setMeleeCooldown(for: attacker, delegate: delegate)
-                    break
-                }
+            for direction in acceptableAttackDirections
+            where isAttacker(attacker, attacking: attackee, from: direction, delegate: delegate) {
+                dealDamage(damage, to: attackee, delegate: delegate)
+                applyKnockback(from: attacker, to: attackee, direction: direction, delegate: delegate)
+                setMeleeCooldown(for: attacker, delegate: delegate)
+                break
             }
         }
     }
@@ -66,7 +65,7 @@ class MeleeAttackStyle: AttackStyle {
             return
         }
         let forceDirection = CGVector(dx: cos(direction.vectorAngle), dy: sin(direction.vectorAngle))
-        let force = forceDirection * knockbackForce
+        let force = forceDirection * knockbackStrength
         attackeePhysicsComponent.physicsBody.applyForce(force)
     }
 

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/AttackableComponent/AttackStyles/MeleeAttackStyle.swift
@@ -8,17 +8,94 @@
 import Foundation
 
 class MeleeAttackStyle: AttackStyle {
+    static let DEFAULT_COOLDOWN_DURATION = 0.3
+    let acceptableAttackDirections: [Direction]
+    var knockbackForce: CGFloat
+    var isCoolingDown: Bool = false
+    var coolDownDuration: CGFloat
+    private var meleeFinishCooldownObserver: NSObjectProtocol?
+
+    init(acceptableAttackDirections: [Direction] = [.left, .right],
+         knockbackForce: CGFloat = 1000.0,
+         cooldownDuration: CGFloat = MeleeAttackStyle.DEFAULT_COOLDOWN_DURATION) {
+        self.acceptableAttackDirections = acceptableAttackDirections
+        self.knockbackForce = knockbackForce
+        self.coolDownDuration = cooldownDuration
+        subscribeToEvents()
+    }
+
+    deinit {
+        if let observer = meleeFinishCooldownObserver {
+            EventManager.shared.unsubscribe(from: observer)
+        }
+    }
+
     func attack(damage: CGFloat, attacker: Entity, attackee: Entity,
                 targetables: [Component.Type], delegate: AttackableDelegate) {
-        guard
-            let attackerRenderableComponent = delegate.getComponent(of: RenderableComponent.self, for: attacker),
-            let attackeeRenderableComponent = delegate.getComponent(of: RenderableComponent.self, for: attackee) else {
-            return
-        }
         if attacker != attackee
             && canAttack(attackee, with: targetables, using: delegate)
-            && attackerRenderableComponent.overlapsWith(attackeeRenderableComponent) {
-            dealDamage(damage, to: attackee, delegate: delegate)
+            && !isCoolingDown {
+            
+            for direction in acceptableAttackDirections {
+                if isAttacker(attacker, attacking: attackee, from: direction, delegate: delegate) {
+                    dealDamage(damage, to: attackee, delegate: delegate)
+                    applyKnockback(from: attacker, to: attackee, direction: direction, delegate: delegate)
+                    setMeleeCooldown(for: attacker, delegate: delegate)
+                    break
+                }
+            }
+        }
+    }
+
+    private func isAttacker(_ attacker: Entity, attacking attackee: Entity,
+                            from direction: Direction, delegate: AttackableDelegate) -> Bool {
+        guard let attackerPhysicsComponent = delegate.getComponent(of: PhysicsComponent.self, for: attacker),
+              let attackeePhysicsComponent = delegate.getComponent(of: PhysicsComponent.self, for: attackee) else {
+            return false
+        }
+        if attackerPhysicsComponent.physicsBody.isCollidingWith(attackeePhysicsComponent.physicsBody,
+                                                                on: direction) {
+            return true
+        }
+        return false
+    }
+
+    private func applyKnockback(from attacker: Entity, to attackee: Entity,
+                                direction: Direction, delegate: AttackableDelegate) {
+        guard let attackeePhysicsComponent = delegate.getComponent(of: PhysicsComponent.self, for: attackee) else {
+            return
+        }
+        let forceDirection = CGVector(dx: cos(direction.vectorAngle), dy: sin(direction.vectorAngle))
+        let force = forceDirection * knockbackForce
+        attackeePhysicsComponent.physicsBody.applyForce(force)
+    }
+
+    private func setMeleeCooldown(for entity: Entity, delegate: AttackableDelegate) {
+        self.isCoolingDown = true
+        let meleeFinishCooldownEvent = MeleeFinishCooldownEvent(meleeAttackStyle: self)
+        let timerComponent = TimerComponent(entity: entity, duration: coolDownDuration, event: meleeFinishCooldownEvent)
+        delegate.addComponent(timerComponent, to: entity)
+    }
+
+    private func subscribeToEvents() {
+        meleeFinishCooldownObserver = EventManager.shared.subscribe(to: MeleeFinishCooldownEvent.self, using: onEventOccur)
+    }
+
+    private lazy var onEventOccur = { [weak self] (event: Event) -> Void in
+        guard let meleeFinishCooldownEvent = event as? MeleeFinishCooldownEvent else {
+            return
+        }
+        meleeFinishCooldownEvent.meleeAttackStyle.isCoolingDown = false
+    }
+
+}
+
+extension Direction {
+    var vectorAngle: CGFloat {
+        switch self {
+        case .left: return 0
+        case .right: return CGFloat.pi
+        default: return 0
         }
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/MovableComponent/Patterns/MoveWhenPushedPattern.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/MovableComponent/Patterns/MoveWhenPushedPattern.swift
@@ -1,0 +1,50 @@
+//
+//  MoveWhenPushedPattern.swift
+//  TheAlienThatEatsTheCarrot
+//
+//  Created by Justin Cheah Yun Fei on 5/4/24.
+//
+
+import Foundation
+
+class MoveWhenPushedPattern: MovementPattern {
+    static let DEFAULT_PUSH_FORCE_MAGNITUDE = 5_000.0
+    var canBePushedFrom: [Direction]
+    var pushForceMagnitude: CGFloat
+
+    init(canBePushedFrom: [Direction],
+         pushForceMagnitude: CGFloat = MoveWhenPushedPattern.DEFAULT_PUSH_FORCE_MAGNITUDE) {
+        self.canBePushedFrom = canBePushedFrom
+        self.pushForceMagnitude = pushForceMagnitude
+    }
+
+    func move(deltaTime: CGFloat, entity: Entity, delegate: MovableDelegate) {
+        guard let physicsComponent = delegate.getComponent(of: PhysicsComponent.self, for: entity) else {
+            return
+        }
+        let playerComponents = delegate.getComponents(of: PlayerComponent.self)
+        for playerComponent in playerComponents {
+            guard let playerPhysicsComponent = delegate.getComponent(of: PhysicsComponent.self, for: playerComponent.entity) else {
+                continue
+            }
+            for direction in canBePushedFrom
+            where playerPhysicsComponent.physicsBody.isCollidingWith(physicsComponent.physicsBody, on: direction) {
+                let forceVector = forceForDirection(direction)
+                physicsComponent.physicsBody.applyForce(forceVector)
+            }
+        }
+    }
+
+    private func forceForDirection(_ direction: Direction) -> CGVector {
+        switch direction {
+        case .left:
+            return CGVector(dx: pushForceMagnitude, dy: 0)
+        case .right:
+            return CGVector(dx: -pushForceMagnitude, dy: 0)
+        case .up:
+            return CGVector(dx: 0, dy: -pushForceMagnitude)
+        case .down:
+            return CGVector(dx: 0, dy: pushForceMagnitude)
+        }
+    }
+}

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PlayerComponent.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PlayerComponent.swift
@@ -22,7 +22,7 @@ class PlayerComponent: Component {
 enum ControlAction {
     case idle, jump, left, right
 
-    static let DEFAULT_LEFT_FORCE = CGVector(dx: -1000.0, dy: 0)
-    static let DEFAULT_RIGHT_FORCE = CGVector(dx: 1000.0, dy: 0)
-    static let DEFAULT_JUMP_FORCE = CGVector(dx: 0, dy: -30000.0)
+    static let DEFAULT_LEFT_FORCE = CGVector(dx: -1_000.0, dy: 0)
+    static let DEFAULT_RIGHT_FORCE = CGVector(dx: 1_000.0, dy: 0)
+    static let DEFAULT_JUMP_FORCE = CGVector(dx: 0, dy: -30_000.0)
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PlayerComponent.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Components/GameComponents/PlayerComponent.swift
@@ -25,4 +25,5 @@ enum ControlAction {
     static let DEFAULT_LEFT_FORCE = CGVector(dx: -1_000.0, dy: 0)
     static let DEFAULT_RIGHT_FORCE = CGVector(dx: 1_000.0, dy: 0)
     static let DEFAULT_JUMP_FORCE = CGVector(dx: 0, dy: -30_000.0)
+    static let DEFAULT_DECELERATION_FORCE_MAGNITUDE = 1_000.0
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/PushableBlockFactory.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/PushableBlockFactory.swift
@@ -6,3 +6,22 @@
 //
 
 import Foundation
+
+class PushableBlockFactory: BlockFactory {
+    override func createComponents() -> [Component] {
+        let size = CGSize(width: boardObject.width, height: boardObject.height)
+        let blockComponent = BlockComponent(entity: entity)
+        let renderableComponent = RenderableComponent(entity: entity,
+                                                      position: boardObject.position,
+                                                      objectType: .block(.pushable),
+                                                      size: size)
+        let physicsBody = PhysicsBody(shape: .rectangle, position: boardObject.position,
+                                      size: size, categoryBitmask: Constants.blockCategoryBitmask,
+                                      collisionBitmask: Constants.blockCollisionBitmask,
+                                      isDynamic: true)
+        let physicsComponent = PhysicsComponent(entity: entity, physicsBody: physicsBody)
+        let movementPattern = MoveWhenPushedPattern(canBePushedFrom: [.left, .right])
+        let movableComponent = MovableComponent(entity: entity, pattern: movementPattern)
+        return [blockComponent, renderableComponent, physicsComponent, movableComponent]
+    }
+}

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/PushableBlockFactory.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/PushableBlockFactory.swift
@@ -1,0 +1,8 @@
+//
+//  PushableBlockFactory.swift
+//  TheAlienThatEatsTheCarrot
+//
+//  Created by Justin Cheah Yun Fei on 5/4/24.
+//
+
+import Foundation

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/SpikeBlockFactory.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Factories/BlockFactories/SpikeBlockFactory.swift
@@ -1,0 +1,38 @@
+//
+//  SpikeBlockFactory.swift
+//  TheAlienThatEatsTheCarrot
+//
+//  Created by Justin Cheah Yun Fei on 5/4/24.
+//
+
+import Foundation
+
+class SpikeBlockFactory: BlockFactory {
+    static let DAMAGE = 20.0
+    static let COOLDOWN = 0.5
+    static let KNOCKBACK_STRENGTH = 1_000.0
+    static let BLOCK_TO_HEIGHT_RATIO = 8.0
+
+    override func createComponents() -> [Component] {
+        let size = CGSize(width: boardObject.width,
+                          height: boardObject.height / SpikeBlockFactory.BLOCK_TO_HEIGHT_RATIO)
+        let blockComponent = BlockComponent(entity: entity)
+        let renderableComponent = RenderableComponent(entity: entity,
+                                                      position: boardObject.position,
+                                                      objectType: .block(.spike),
+                                                      size: size)
+        let physicsBody = PhysicsBody(shape: .rectangle, position: boardObject.position,
+                                      size: size, categoryBitmask: Constants.blockCategoryBitmask,
+                                      collisionBitmask: Constants.blockCollisionBitmask,
+                                      isDynamic: false)
+        let physicsComponent = PhysicsComponent(entity: entity, physicsBody: physicsBody)
+        let attackStyle = MeleeAttackStyle(acceptableAttackDirections: [.up, .left, .down],
+                                           knockbackStrength: SpikeBlockFactory.KNOCKBACK_STRENGTH,
+                                           cooldownDuration: SpikeBlockFactory.COOLDOWN)
+        let attackableComponent = AttackableComponent(entity: entity,
+                                                      targetables: [PlayerComponent.self],
+                                                      damage: SpikeBlockFactory.DAMAGE,
+                                                      attackStyle: attackStyle)
+        return [blockComponent, renderableComponent, physicsComponent, attackableComponent]
+    }
+}

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Nexus+Extensions.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Nexus+Extensions.swift
@@ -77,7 +77,7 @@ extension Nexus {
         case .pushable:
             fatalError("TODO: implement")
         case .spike:
-            fatalError("TODO: implement")
+            return getSpikeBlockFactory(from: entity, block: block)
         case .powerup:
             fatalError("TODO: implement")
         }
@@ -140,6 +140,11 @@ extension Nexus {
     private func getGroundBlockFactory(from entity: Entity,
                                        block: Block) -> EntityFactory {
         GroundBlockFactory(from: block, to: entity)
+    }
+
+    private func getSpikeBlockFactory(from entity: Entity,
+                                      block: Block) -> EntityFactory {
+        SpikeBlockFactory(from: block, to: entity)
     }
 }
 

--- a/TheAlienThatEatsTheCarrot/GameEngine/Entities/Nexus+Extensions.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Entities/Nexus+Extensions.swift
@@ -75,7 +75,7 @@ extension Nexus {
         case .breakable:
             fatalError("TODO: implement")
         case .pushable:
-            fatalError("TODO: implement")
+            return getPushableBlockFactory(from: entity, block: block)
         case .spike:
             return getSpikeBlockFactory(from: entity, block: block)
         case .powerup:
@@ -145,6 +145,11 @@ extension Nexus {
     private func getSpikeBlockFactory(from entity: Entity,
                                       block: Block) -> EntityFactory {
         SpikeBlockFactory(from: block, to: entity)
+    }
+
+    private func getPushableBlockFactory(from entity: Entity,
+                                      block: Block) -> EntityFactory {
+        PushableBlockFactory(from: block, to: entity)
     }
 }
 

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
@@ -19,7 +19,9 @@ final class CollisionSystem: System {
 
     func update(deltaTime: CGFloat) {
         // Strategy used from https://gamedev.stackexchange.com/questions/16813/handling-collisions-with-ground
-        let toIgnore = getPhysicsComponentsToDisableGravity()
+        // If a physics body is standing on the ground (block) with negligible y speed, we disable gravity and
+        // skip collision resolution with that ground
+        let toIgnore = getToIgnoresAndHandleGroundedPhysicsBodies()
         let allPhysicsBodies = nexus.getComponents(of: PhysicsComponent.self).map { $0.physicsBody }
         physicsWorld.resolveCollisions(for: allPhysicsBodies, deltaTime: deltaTime, toIgnore: toIgnore)
     }
@@ -28,7 +30,7 @@ final class CollisionSystem: System {
         nexus.removeComponents(of: CollisionComponent.self)
     }
 
-    private func getPhysicsComponentsToDisableGravity() -> Set<[PhysicsBody]> {
+    private func getToIgnoresAndHandleGroundedPhysicsBodies() -> Set<[PhysicsBody]> {
         var toIgnore: Set<[PhysicsBody]> = Set()
         let physicsComponents = nexus.getComponents(of: PhysicsComponent.self)
         let groundPhysicsComponents = physicsComponents.filter {

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/CollisionSystem.swift
@@ -36,23 +36,23 @@ final class CollisionSystem: System {
         let groundPhysicsComponents = physicsComponents.filter {
             nexus.containsComponent(for: $0.entity, of: BlockComponent.self)
         }
-        let notGroundPhysicsComponents = physicsComponents.filter {
-            !nexus.containsComponent(for: $0.entity, of: BlockComponent.self)
+        let dynamicComponents = physicsComponents.filter {
+            $0.physicsBody.isDynamic
         }
-        for notGroundPhysicsComponent in notGroundPhysicsComponents {
+        for dynamicComponent in dynamicComponents {
             var isCollidingWithGround = false
             for groundPhysicsComponent in groundPhysicsComponents {
-                if notGroundPhysicsComponent.physicsBody.isCollidingWith(groundPhysicsComponent.physicsBody, on: Direction.up)
-                    && notGroundPhysicsComponent.physicsBody.hasNegligibleYVelocity() {
-                    disableGravity(for: notGroundPhysicsComponent)
+                if dynamicComponent.physicsBody.isCollidingWith(groundPhysicsComponent.physicsBody, on: Direction.up)
+                    && dynamicComponent.physicsBody.hasNegligibleYVelocity() {
+                    disableGravity(for: dynamicComponent)
                     isCollidingWithGround = true
-                    toIgnore.insert([notGroundPhysicsComponent.physicsBody, groundPhysicsComponent.physicsBody])
-                } else if !notGroundPhysicsComponent.physicsBody.hasNegligibleYVelocity() {
-                    restoreGravity(for: notGroundPhysicsComponent)
+                    toIgnore.insert([dynamicComponent.physicsBody, groundPhysicsComponent.physicsBody])
+                } else if !dynamicComponent.physicsBody.hasNegligibleYVelocity() {
+                    restoreGravity(for: dynamicComponent)
                 }
             }
             if !isCollidingWithGround {
-                restoreGravity(for: notGroundPhysicsComponent)
+                restoreGravity(for: dynamicComponent)
             }
         }
         return toIgnore

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/DamageSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/DamageSystem.swift
@@ -48,6 +48,11 @@ class DamageSystem: System, AttackableDelegate {
             print("Player died!")
         }
     }
+
+    func addComponent<T: Component>(_ component: T, to entity: Entity) {
+        nexus.addComponent(component, to: entity)
+    }
+
     func getComponent<T>(of type: T.Type, for entity: Entity) -> T? where T: Component {
         nexus.getComponent(of: type, for: entity)
     }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/MovementSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/MovementSystem.swift
@@ -40,4 +40,8 @@ class MovementSystem: System, MovableDelegate {
     func getComponent<T>(of type: T.Type, for entity: Entity) -> T? where T: Component {
         nexus.getComponent(of: type, for: entity)
     }
+
+    func getComponents<T>(of type: T.Type) -> [T] where T : Component {
+        nexus.getComponents(of: type)
+    }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
@@ -8,7 +8,7 @@
 import CoreGraphics
 
 final class PhysicsSystem: System {
-    static let GRAVITY_FORCE = CGVector(dx: 0, dy: 1000.0)
+    static let GRAVITY_FORCE = CGVector(dx: 0, dy: 1_000.0)
     let nexus: Nexus
     let physicsWorld: PhysicsWorld
 

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PhysicsSystem.swift
@@ -44,13 +44,10 @@ final class PhysicsSystem: System {
     }
 
     private func applyGravityTo(_ entity: Entity) {
-        if !nexus.containsAnyComponent(of: [PlayerComponent.self, EnemyComponent.self], in: entity) {
-            return
-        }
         guard let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: entity) else {
             return
         }
-        if physicsComponent.disableGravity {
+        if physicsComponent.disableGravity || !physicsComponent.physicsBody.isDynamic {
             return
         }
         physicsComponent.physicsBody.applyForce(PhysicsSystem.GRAVITY_FORCE)

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/PlayerMovementSystem.swift
@@ -67,7 +67,7 @@ class PlayerMovementSystem: System {
     private func applyPhysicsBasedOnControlAction(for player: PlayerComponent) {
         switch player.action {
         case .idle:
-            doNothing()
+            applyFrictionalForce(for: player)
         case .jump:
             jumpIfPlayerHasJumpsAvailable(for: player)
         case .left:
@@ -93,8 +93,11 @@ class PlayerMovementSystem: System {
         camera.updateCameraBoundsFromCenter(center: renderableComponent.position)
     }
 
-    private func doNothing() {
-        // do nothing
+    private func applyFrictionalForce(for player: PlayerComponent) {
+        guard let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: player.entity) else {
+            return
+        }
+        physicsComponent.physicsBody.applyFrictionalForceInX(magnitude: ControlAction.DEFAULT_DECELERATION_FORCE_MAGNITUDE)
     }
 
     private func jumpIfPlayerHasJumpsAvailable(for player: PlayerComponent) {
@@ -112,13 +115,9 @@ class PlayerMovementSystem: System {
     }
 
     private func addHorizontalForce(for player: PlayerComponent, force: CGVector) {
-        guard
-            let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: player.entity),
-            let jumpStateComponent = nexus.getComponent(of: JumpStateComponent.self, for: player.entity) else {
+        guard let physicsComponent = nexus.getComponent(of: PhysicsComponent.self, for: player.entity) else {
             return
         }
-        if jumpStateComponent.isGrounded {
-            physicsComponent.physicsBody.applyForce(force)
-        }
+        physicsComponent.physicsBody.applyForce(force)
     }
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/Utilities/AttackableDelegate.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/Utilities/AttackableDelegate.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol AttackableDelegate {
     func getComponent<T: Component>(of type: T.Type, for entity: Entity) -> T?
+    func addComponent<T: Component>(_ component: T, to entity: Entity)
 
     func removeComponent<T: Component>(_ component: T, from entity: Entity) where T: AnyObject
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/Utilities/MovableDelegate.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Systems/GameSystems/Utilities/MovableDelegate.swift
@@ -9,4 +9,6 @@ import Foundation
 
 protocol MovableDelegate {
     func getComponent<T: Component>(of type: T.Type, for entity: Entity) -> T?
+
+    func getComponents<T: Component>(of type: T.Type) -> [T]
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Utilities/Direction.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Utilities/Direction.swift
@@ -7,27 +7,6 @@
 
 import Foundation
 
-struct Direction: Equatable {
-    var radians: Double {
-        didSet {
-            radians = radians.truncatingRemainder(dividingBy: 2 * .pi)
-        }
-    }
-    var degrees: Double {
-        get { radians * 180 / .pi }
-        set { radians = newValue * .pi / 180 }
-    }
-
-    init(radians: Double) {
-        self.radians = radians.truncatingRemainder(dividingBy: 2 * .pi)
-    }
-
-    init(degrees: Double) {
-        self.init(radians: degrees * .pi / 180)
-    }
-
-    static let up = Direction(radians: .pi * 1.5)
-    static let down = Direction(radians: .pi / 2)
-    static let left = Direction(radians: 0)
-    static let right = Direction(radians: .pi)
+enum Direction: Equatable {
+    case left, right, up, down
 }

--- a/TheAlienThatEatsTheCarrot/GameEngine/Utilities/GameStats.swift
+++ b/TheAlienThatEatsTheCarrot/GameEngine/Utilities/GameStats.swift
@@ -12,11 +12,4 @@ struct GameStats {
     let carrots: [Int]
     let scores: [CGFloat]
     let lives: [Int]
-
-    init(coins: [Int], carrots: [Int], scores: [CGFloat], lives: [Int]) {
-        self.coins = coins
-        self.carrots = carrots
-        self.scores = scores
-        self.lives = lives
-    }
 }

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
@@ -97,7 +97,7 @@ extension PhysicsBody {
             return false
         }
         let collisionAngle = collisionPoints.normal.angle
-        var angleInDegrees = (collisionAngle * 180 / Double.pi).truncatingRemainder(dividingBy: 360)
+        let angleInDegrees = (collisionAngle * 180 / Double.pi).truncatingRemainder(dividingBy: 360)
         switch direction {
         case .up:
             return (-135...(-45)).contains(angleInDegrees)
@@ -107,8 +107,6 @@ extension PhysicsBody {
             return (135...180).contains(angleInDegrees) || (-180...(-135)).contains(angleInDegrees)
         case .right:
             return (-45...45).contains(angleInDegrees)
-        default:
-            return false
         }
     }
 }

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsBody.swift
@@ -112,3 +112,16 @@ extension PhysicsBody {
         }
     }
 }
+
+extension PhysicsBody {
+    func applyFrictionalForceInX(magnitude: CGFloat) {
+        var frictionalForceX = -velocity.dx.sign * magnitude
+        if velocity.dx.sign == frictionalForceX.sign {
+            let potentialVelocity = velocity.dx + frictionalForceX
+            if potentialVelocity.sign != velocity.dx.sign {
+                frictionalForceX = -velocity.dx
+            }
+        }
+        applyForce(CGVector(dx: frictionalForceX, dy: 0))
+    }
+}

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsConstants.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsConstants.swift
@@ -11,5 +11,5 @@ struct PhysicsConstants {
     // Physics Constants TODO: adjust based on game design
     static let physicsBodyMinimumSize: CGFloat = 0.05
     static let restitution: CGFloat = 0.8
-    static let maxSpeed: CGFloat = 5000
+    static let maxSpeed: CGFloat = 5_000
 }

--- a/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsWorld.swift
+++ b/TheAlienThatEatsTheCarrot/PhysicsEngine/PhysicsWorld.swift
@@ -59,7 +59,7 @@ final class PhysicsWorld {
     }
 
     private func toBeIgnored(_ bodyA: PhysicsBody, _ bodyB: PhysicsBody, toIgnore: Set<[PhysicsBody]>) -> Bool {
-        return toIgnore.contains([bodyA, bodyB]) || toIgnore.contains([bodyB, bodyA])
+        toIgnore.contains([bodyA, bodyB]) || toIgnore.contains([bodyB, bodyA])
     }
 
     private func publishCollisions(_ currentCollisions: Set<Collision>) {

--- a/TheAlienThatEatsTheCarrot/Utilities/CGFloat+extensions.swift
+++ b/TheAlienThatEatsTheCarrot/Utilities/CGFloat+extensions.swift
@@ -17,4 +17,14 @@ extension CGFloat {
         let max = vec1 > vec2 ? vec1 : vec2
         return self < min ? min : (self > max ? max : self)
     }
+    
+    var sign: CGFloat {
+        if self > 0 {
+            return 1.0
+        } else if self < 0 {
+            return -1.0
+        } else {
+            return 0.0
+        }
+    }
 }

--- a/TheAlienThatEatsTheCarrot/Utilities/CGPoint+extensions.swift
+++ b/TheAlienThatEatsTheCarrot/Utilities/CGPoint+extensions.swift
@@ -17,6 +17,10 @@ extension CGPoint {
         lhs = CGPoint(x: lhs.x + rhs.dx, y: lhs.y + rhs.dy)
     }
 
+    static func -= (lhs: inout CGPoint, rhs: CGVector) {
+        lhs = CGPoint(x: lhs.x - rhs.dx, y: lhs.y - rhs.dy)
+    }
+
     static func - (lhs: CGPoint, rhs: CGVector) -> CGPoint {
         CGPoint(x: lhs.x - rhs.dx, y: lhs.y - rhs.dy)
     }

--- a/TheAlienThatEatsTheCarrot/Utilities/Constants.swift
+++ b/TheAlienThatEatsTheCarrot/Utilities/Constants.swift
@@ -21,7 +21,7 @@ struct Constants {
     // Collision Bitmasks
     static let characterCollisionBitmask: UInt32 = enemyCategoryBitmask | blockCategoryBitmask
     static let enemyCollisionBitmask: UInt32 = characterCategoryBitmask | blockCategoryBitmask
-    static let blockCollisionBitmask: UInt32 = characterCategoryBitmask
+    static let blockCollisionBitmask: UInt32 = characterCategoryBitmask | blockCategoryBitmask | enemyCategoryBitmask
     static let powerupCollisionBitmask: UInt32 = 0
     static let collectibleCollisionBitmask: UInt32 = 0
 }


### PR DESCRIPTION
### MeleeAttack
- MeleeAttackStyle now accepts attack directions as input (melee can attack left, right, up, down, or any combination)
- MeleeAttackStyle now use physics collision direction check to deal damage instead of renderable overlap check
- MeleeAttackStyle now implements cooldown (can only attack once every cooldown)
- MeleeAttackStyle now deals slight knockback

### JumpAttack
- Fix bug where enemy takes damage even though player not jumping on it, by merely overlapping with it (add a condition to check if the y velocity is negligible before attacking)

### PlayerMovement
- Add deceleration for player when idling. Currently movement feels like walking on ice.
Note: This might appear a bit hard-codey since we are applying frictional force within the movement system. Ideally, we should allow the blocks or atmosphere to handle that. Since it is possible that the friction might be different for different block types. Or when the player is in the air, the friction might be different depending no the "air type" eg. if we implement water in the future, or if the player is in space etc. However this implementation would open up quite a bit of challenges to implement.

### SpikeBlock
spike block is basically just a block with an attackable component with attack direction from left right and down

### PushableBlock
It is implemented by using the movableComponent similar to the enemies. Instead of LeftRightPattern (for normal enemy), or RandomPattern (for fast enemy), it uses the MoveWhenPushedPattern. Which as the name suggests, will only move when it is being pushed by any player. You can set the direction it can be pushed from. By default it is [.left, .right]

### Other notable changes
- Change `Direction` to an enum
- Apply disable gravity and collision skipping to dynamic objects instead of just non-block objects (since pushable blocks should be applied to as well)